### PR TITLE
Improve Card Navigation Margins

### DIFF
--- a/src/main/java/de/maulmann/CardPageGenerator.java
+++ b/src/main/java/de/maulmann/CardPageGenerator.java
@@ -196,12 +196,12 @@ public class CardPageGenerator {
         sb.append(SharedTemplates.getTopNav(ROOT, "collection"));
 
         // SUB-NAV (Overview, Prev, Next)
-        sb.append("<nav class=\"detail-nav\" style=\"display: flex; justify-content: space-between; align-items: center; width: 100%; border: none; background: transparent;\">\n");
+        sb.append("<nav class=\"detail-nav\" style=\"border: none; background: transparent;\">\n");
         sb.append("    <a href=\"../../Juwan-Howard-Collection.html\" class=\"modern-button\" style=\"text-decoration:none;\" title=\"Return to the complete card collection overview\">&larr; Overview</a>\n");
-        sb.append("    <div>\n");
+        sb.append("    <div style=\"display: flex; gap: 10px;\">\n");
         if (prev != null) {
             String prevTitle = "Go to previous card: " + prev.get("Season") + " " + prev.get("Brand");
-            sb.append("        <a id=\"prevCardLink\" href=\"").append(prev.filename).append("\" title=\"").append(prevTitle).append("\" style=\"margin-right:10px; text-decoration:none;\">&laquo; Prev</a>\n");
+            sb.append("        <a id=\"prevCardLink\" href=\"").append(prev.filename).append("\" title=\"").append(prevTitle).append("\" style=\"text-decoration:none;\">&laquo; Prev</a>\n");
         }
         if (next != null) {
             String nextTitle = "Go to next card: " + next.get("Season") + " " + next.get("Brand");

--- a/src/main/resources/css/main.css
+++ b/src/main/resources/css/main.css
@@ -168,12 +168,14 @@ table tr td:first-child a:hover {
 }
 
 .detail-nav {
-    padding: 20px;
+    padding: 20px 5%;
     background: #f8f9fa;
     border-bottom: 1px solid #e9ecef;
     display: flex;
     justify-content: space-between;
-    align-items: center
+    align-items: center;
+    box-sizing: border-box;
+    width: 100%
 }
 
 .detail-main {


### PR DESCRIPTION
This change improves the layout of the navigation bar on individual card pages. By adding horizontal padding to the navigation container in the CSS and removing conflicting inline styles in the Java generator, the 'Overview' and 'Prev/Next' buttons now have consistent and appropriate spacing relative to the page edges, preventing them from being too close to the window boundary.

---
*PR created automatically by Jules for task [15213795401633892220](https://jules.google.com/task/15213795401633892220) started by @AndreasBild*