### PR TITLE
Improve visibility of the season selection drop-down

### DIFF
--- a/src/main/java/de/maulmann/FileGenerator.java
+++ b/src/main/java/de/maulmann/FileGenerator.java
@@ -160,7 +160,7 @@ public class FileGenerator {
         final StringBuilder internalAnchorList = new StringBuilder();
         internalAnchorList.append("<div style='margin: 20px 0; text-align: left;'>");
         internalAnchorList.append("<label for='season-select' style='margin-right: 10px; font-weight: bold;'>Jump to Season:</label>");
-        internalAnchorList.append("<select id='season-select' class='modern-button' style='background-color:#4f9e06; width: auto; min-width: 220px; cursor: pointer;' onchange=\"if(this.value) window.location.hash = this.value;\">");
+        internalAnchorList.append("<select id='season-select' class='modern-button' style='width: auto; min-width: 220px;' onchange=\"if(this.value) window.location.hash = this.value;\">");
         internalAnchorList.append("<option value=''>-- Select a Season --</option>");
 
         for (final String fileName : fileNames) {

--- a/src/main/resources/css/main.css
+++ b/src/main/resources/css/main.css
@@ -124,7 +124,12 @@ a:focus, a:focus-visible, button:focus {
     box-sizing: border-box;
     font-size: .95rem;
     white-space: normal;
-    line-height: 1.2
+    line-height: 1.2;
+    color: #fff;
+    background-color: #3a7504;
+    border-radius: 6px;
+    border: none;
+    cursor: pointer;
 }
 
 select.modern-button {


### PR DESCRIPTION
The season selection drop-down on the Collection page had poor text visibility due to dark text on a green background. This change sets a clear white text color and a darker green background in the global stylesheet (`main.css`) for the `.modern-button` class, which the drop-down uses. It also removes redundant and conflicting inline styles from the Java generator to ensure the CSS is correctly applied. Visual verification confirmed that the text is now clearly legible.

---
*PR created automatically by Jules for task [8659437646847040677](https://jules.google.com/task/8659437646847040677) started by @AndreasBild*