### PR TITLE
Fix burger menu in top navigation

### DIFF
--- a/src/main/resources/css/main.css
+++ b/src/main/resources/css/main.css
@@ -189,6 +189,23 @@ tr:hover {
     .detail-header h1 {
         font-size: 1.5rem;
     }
+
+    /* Burger Menu - Responsive Classes */
+    .topnav.responsive {
+        position: relative;
+    }
+
+    .topnav.responsive .icon {
+        position: absolute;
+        right: 0;
+        top: 0;
+    }
+
+    .topnav.responsive a {
+        float: none;
+        display: block;
+        text-align: left;
+    }
 }
 
 /* --- LANDSCAPE OPTIMIERUNG (Handy Querformat) --- */


### PR DESCRIPTION
The burger menu in the top navigation was non-functional on mobile devices because the CSS for the expanded state (`.topnav.responsive`) was missing. This change adds the required styles to `src/main/resources/css/main.css`, allowing the menu to correctly display all navigation links when the toggle button is clicked. The fix was verified using a Playwright script that simulated a mobile viewport and captured screenshots/videos of the menu in both closed and open states.

---
*PR created automatically by Jules for task [13868347279487069336](https://jules.google.com/task/13868347279487069336) started by @AndreasBild*