### PR TITLE
Fix oversized card image resolution and selection

### DIFF
--- a/src/main/java/de/maulmann/ImageConverter.java
+++ b/src/main/java/de/maulmann/ImageConverter.java
@@ -16,14 +16,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class ImageConverter {
 
     // --- Configuration ---
-    private static final int MAX_WIDTH = 1000;
-    private static final int MAX_HEIGHT = 700;
+    private static final int MAX_WIDTH = 1200;
+    private static final int MAX_HEIGHT = 1600;
 
     // Definition der Responsive-Breiten für das srcset
     private static final int[] RESPONSIVE_WIDTHS = {400, 600};
 
-    // Mac CLI Path zu Homebrew cwebp
-    private static final String CWEBP_PATH = "/opt/homebrew/bin/cwebp";
+    // Dynamic discovery of cwebp
+    private static final String CWEBP_PATH = findCwebp();
 
     // Zähler für die Zusammenfassung
     private static final AtomicInteger successCount = new AtomicInteger(0);
@@ -127,11 +127,7 @@ public class ImageConverter {
         }
 
         // 3. Smart Scaling für das Hauptbild
-        boolean isPortrait = origH > origW;
-        int currentMaxWidth = isPortrait ? MAX_HEIGHT : MAX_WIDTH;
-        int currentMaxHeight = isPortrait ? MAX_WIDTH : MAX_HEIGHT;
-
-        double ratio = Math.min((double) currentMaxWidth / origW, (double) currentMaxHeight / origH);
+        double ratio = Math.min((double) MAX_WIDTH / origW, (double) MAX_HEIGHT / origH);
         int mainW = ratio < 1.0 ? (int) (origW * ratio) : origW;
         int mainH = ratio < 1.0 ? (int) (origH * ratio) : origH;
 
@@ -170,6 +166,24 @@ public class ImageConverter {
         if (exitCode != 0) {
             throw new IOException("cwebp fehlerhaft mit Code " + exitCode);
         }
+    }
+
+    private static String findCwebp() {
+        String[] paths = {
+            "cwebp",
+            "/usr/bin/cwebp",
+            "/usr/local/bin/cwebp",
+            "/opt/homebrew/bin/cwebp",
+            "/usr/sbin/cwebp",
+            "/bin/cwebp"
+        };
+        for (String path : paths) {
+            try {
+                Process p = new ProcessBuilder(path, "-version").start();
+                if (p.waitFor() == 0) return path;
+            } catch (Exception ignored) {}
+        }
+        return "cwebp"; // Fallback to PATH
     }
 
     private static String getBaseName(String fileName) {

--- a/src/main/resources/templates/card-detail.ftlh
+++ b/src/main/resources/templates/card-detail.ftlh
@@ -6,7 +6,7 @@
     <link rel="preload" as="image" href="${frontImgPath}"
           imagesrcset="${frontImgPath?replace('.webp', '-400w.webp')} 400w,
                        ${frontImgPath?replace('.webp', '-600w.webp')} 600w,
-                       ${frontImgPath} 1000w"
+                       ${frontImgPath} 1200w"
           imagesizes="(max-width: 600px) 100vw, (max-width: 1024px) 50vw, (max-width: 1300px) 45vw, 600px"
           fetchpriority="high">
     ${jsonLd?no_esc}
@@ -41,7 +41,7 @@ ${topNavHtml?no_esc}
             <img src="${frontImgPath}"
                  srcset="${frontImgPath?replace('.webp', '-400w.webp')} 400w,
                          ${frontImgPath?replace('.webp', '-600w.webp')} 600w,
-                         ${frontImgPath} 1000w"
+                         ${frontImgPath} 1200w"
                  sizes="(max-width: 600px) 100vw, (max-width: 1024px) 50vw, (max-width: 1300px) 45vw, 600px"
                  alt="${frontAlt}" title="${frontImgTitle}"
                  fetchpriority="high" class="zoomable-img"
@@ -53,7 +53,7 @@ ${topNavHtml?no_esc}
             <img src="${backImgPath}"
                  srcset="${backImgPath?replace('.webp', '-400w.webp')} 400w,
                          ${backImgPath?replace('.webp', '-600w.webp')} 600w,
-                         ${backImgPath} 1000w"
+                         ${backImgPath} 1200w"
                  sizes="(max-width: 600px) 100vw, (max-width: 1024px) 50vw, (max-width: 1300px) 45vw, 600px"
                  alt="${backAlt}" title="${backImgTitle}" loading="lazy"
                  class="zoomable-img"


### PR DESCRIPTION
The issue was that "oversized" cards (particularly those with a high aspect ratio like 'Tallboys') were being limited by a 1000px height cap in the image converter. This resulted in a width significantly less than 600px, which prevented the generation of the `-600w.webp` responsive variant that the UI template expected.

This PR:
1. Increases the maximum bounding box in `ImageConverter.java` to 1200x1600px, ensuring that even very tall cards maintain a width of at least 600px for their main asset.
2. Updates `card-detail.ftlh` to use the `1200w` descriptor in `srcset`, providing browsers with accurate information for high-quality desktop rendering.
3. Adds a more robust way to find the `cwebp` binary on different systems.
4. Ensures all test/junk files from the investigation are removed.

---
*PR created automatically by Jules for task [13530816410765479841](https://jules.google.com/task/13530816410765479841) started by @AndreasBild*