### PR TITLE
Enhance Carousel with Card Detail Links

### DIFF
--- a/src/main/resources/css/main.css
+++ b/src/main/resources/css/main.css
@@ -278,6 +278,39 @@ tr:hover {
     display: block;
 }
 
+.carousel-item .hover-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.4);
+    border-radius: 10px;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+}
+
+.carousel-item:hover .hover-overlay {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.carousel-item .view-button {
+    background-color: #3a7504;
+    color: white;
+    padding: 10px 20px;
+    border-radius: 6px;
+    text-decoration: none;
+    font-weight: bold;
+    font-size: 0.9em;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+    white-space: nowrap;
+}
+
 /* Mobile Optimierung für das Karussell */
 @media (max-width: 600px) {
     .carousel-item {

--- a/src/main/resources/templates/index.ftlh
+++ b/src/main/resources/templates/index.ftlh
@@ -121,70 +121,112 @@ ${topNavHtml?no_esc}
                 <img src="images/1997-98/Juwan-Howard-Washington-Bullets-1997-98-Fleer-Fleer-Metal-Universe-Base-Set-Precious-Metal-Gems-Red-33-sn47-front-400w.webp"
                      fetchpriority="high" width="400" height="550"
                      alt="Juwan Howard 1997-98 Fleer Metal Universe Precious Metal Gems Red">
+                <div class="hover-overlay">
+                    <a href="cards/1997-98/Juwan-Howard-Washington-Bullets-1997-98-Fleer-Fleer-Metal-Universe-Base-Set-Precious-Metal-Gems-Red-33-sn47-375.html" class="view-button" title="View details for Juwan Howard 1997-98 Fleer Metal Universe Precious Metal Gems Red">View Details</a>
+                </div>
             </div>
             <div class="carousel-item">
                 <img src="images/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Fleer-Fleer-Vintage-61-Base-Set-Classic-5C-sn16-front-400w.webp"
                      fetchpriority="high" width="400" height="550"
                      alt="Juwan Howard 1998-99 Fleer Vintage 61 Base Classic 5C">
+                <div class="hover-overlay">
+                    <a href="cards/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Fleer-Fleer-Vintage-61-Base-Set-Classic-5C-sn16-509.html" class="view-button" title="View details for Juwan Howard 1998-99 Fleer Vintage 61 Base Classic 5C">View Details</a>
+                </div>
             </div>
             <div class="carousel-item">
                 <img src="images/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Fleer-Fleer-Metal-Universe-Base-Set-Precious-Metal-Gems-5-sn33-front-400w.webp"
                      fetchpriority="high" width="400" height="550"
                      alt="Juwan Howard 1998-99 Fleer Metal Universe Precious Metal Gems 5">
+                <div class="hover-overlay">
+                    <a href="cards/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Fleer-Fleer-Metal-Universe-Base-Set-Precious-Metal-Gems-5-sn33-513.html" class="view-button" title="View details for Juwan Howard 1998-99 Fleer Metal Universe Precious Metal Gems 5">View Details</a>
+                </div>
             </div>
             <div class="carousel-item">
                 <img src="images/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Fleer-Fleer-Brilliants-Base-Set-24-K-Gold-97TG-sn14-front-400w.webp"
                      fetchpriority="high" width="400" height="550"
                      alt="Juwan Howard 1998-99 Fleer Brilliants Base 24 K Gold 97TG">
+                <div class="hover-overlay">
+                    <a href="cards/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Fleer-Fleer-Brilliants-Base-Set-24-K-Gold-97TG-sn14-507.html" class="view-button" title="View details for Juwan Howard 1998-99 Fleer Brilliants Base 24 K Gold 97TG">View Details</a>
+                </div>
             </div>
             <div class="carousel-item">
                 <img src="images/2018-19/Juwan-Howard-Washington-Wizards-2018-19-Panini-Panini-Contenders-Optic-Contenders-Autographs-Gold-Vinyl-LC-JWH-sn1-front-400w.webp"
                      fetchpriority="high" width="400" height="550"
                      alt="Juwan Howard 2018-19 Panini Panini Contenders Optic Contenders Autographs Gold Vinyl LC JWH">
+                <div class="hover-overlay">
+                    <a href="cards/2018-19/Juwan-Howard-Washington-Wizards-2018-19-Panini-Panini-Contenders-Optic-Contenders-Autographs-Gold-Vinyl-LC-JWH-sn1-1266.html" class="view-button" title="View details for Juwan Howard 2018-19 Panini Panini Contenders Optic Contenders Autographs Gold Vinyl LC JWH">View Details</a>
+                </div>
             </div>
             <div class="carousel-item">
                 <img src="images/1997-98/Juwan-Howard-Washington-Bullets-1997-98-Fleer-Fleer-Metal-Universe-Base-Set-Precious-Metal-Gems-Green-33-sn7-front-400w.webp"
                      fetchpriority="high" width="400" height="550"
                      alt="Juwan Howard 1997-98 Fleer Metal Universe Precious Metal Gems Green">
+                <div class="hover-overlay">
+                    <a href="cards/1997-98/Juwan-Howard-Washington-Bullets-1997-98-Fleer-Fleer-Metal-Universe-Base-Set-Precious-Metal-Gems-Green-33-sn7-376.html" class="view-button" title="View details for Juwan Howard 1997-98 Fleer Metal Universe Precious Metal Gems Green">View Details</a>
+                </div>
             </div>
             <div class="carousel-item">
                 <img src="images/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Upper-Deck-SPx-Finite-Base-Set-Spectrum-76-sn291-front-400w.webp"
                      loading="lazy" width="400" height="550" alt="Juwan Howard 1998-99 SPx Finite Base Spectrum">
+                <div class="hover-overlay">
+                    <a href="cards/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Upper-Deck-SPx-Finite-Base-Set-Spectrum-76-sn291-537.html" class="view-button" title="View details for Juwan Howard 1998-99 SPx Finite Base Spectrum">View Details</a>
+                </div>
             </div>
             <div class="carousel-item">
                 <img src="images/1997-98/Juwan-Howard-Washington-Wizards-1997-98-Fleer-Fleer-Metal-Universe-Championship-Base-Set-Precious-Metal-Gems-11-sn32-front-400w.webp"
                      loading="lazy" width="400" height="550"
                      alt="1997-98 Fleer Metal Universe Championship Precious Metal Gems 11">
+                <div class="hover-overlay">
+                    <a href="cards/1997-98/Juwan-Howard-Washington-Wizards-1997-98-Fleer-Fleer-Metal-Universe-Championship-Base-Set-Precious-Metal-Gems-11-sn32-371.html" class="view-button" title="View details for 1997-98 Fleer Metal Universe Championship Precious Metal Gems 11">View Details</a>
+                </div>
             </div>
             <div class="carousel-item">
                 <img src="images/2022-23/Juwan-Howard-Washington-Wizards-2022-23-Panini-Panini-Spectra-Icons-Autographs-Nebula-IA-JUW-sn1-front-400w.webp"
                      loading="lazy" width="400" height="550"
                      alt="2022-23 Panini Panini Spectra Icons Autographs Nebula IA JUW">
+                <div class="hover-overlay">
+                    <a href="cards/2022-23/Juwan-Howard-Washington-Wizards-2022-23-Panini-Panini-Spectra-Icons-Autographs-Nebula-IA-JUW-sn1-1348.html" class="view-button" title="View details for 2022-23 Panini Panini Spectra Icons Autographs Nebula IA JUW">View Details</a>
+                </div>
             </div>
             <div class="carousel-item">
                 <img src="images/2018-19/Juwan-Howard-Miami-Heat-2018-19-Panini-Panini-Flawless-Legendary-Scripts-Platinum-LS-JWH-sn1-front-400w.webp"
                      loading="lazy" width="400" height="550"
                      alt="2018-19 Panini Panini Flawless Legendary Scripts Platinum LS JWH">
+                <div class="hover-overlay">
+                    <a href="cards/2018-19/Juwan-Howard-Miami-Heat-2018-19-Panini-Panini-Flawless-Legendary-Scripts-Platinum-LS-JWH-sn1-1245.html" class="view-button" title="View details for 2018-19 Panini Panini Flawless Legendary Scripts Platinum LS JWH">View Details</a>
+                </div>
             </div>
             <div class="carousel-item">
                 <img src="images/2016-17/Juwan-Howard-Miami-Heat-2016-17-Panini-Panini-Donruss-Elite-Signatures-Black-99-sn1-front-400w.webp"
                      loading="lazy" width="400" height="550"
                      alt="2016-17 Panini Panini Donruss Elite Signatures Black 99">
+                <div class="hover-overlay">
+                    <a href="cards/2016-17/Juwan-Howard-Miami-Heat-2016-17-Panini-Panini-Donruss-Elite-Signatures-Black-99-sn1-1205.html" class="view-button" title="View details for 2016-17 Panini Panini Donruss Elite Signatures Black 99">View Details</a>
+                </div>
             </div>
             <div class="carousel-item">
                 <img src="images/2017-18/Juwan-Howard-Dallas-Mavericks-2017-18-Panini-Panini-Donruss-Optic-Dominator-Signatures-Gold-Vinyl-18-sn1-front-400w.webp"
                      loading="lazy" width="400" height="550"
                      alt="2017-18 Panini Panini Donruss Optic Dominator Signatures Gold Vinyl 18">
+                <div class="hover-overlay">
+                    <a href="cards/2017-18/Juwan-Howard-Dallas-Mavericks-2017-18-Panini-Panini-Donruss-Optic-Dominator-Signatures-Gold-Vinyl-18-sn1-1236.html" class="view-button" title="View details for 2017-18 Panini Panini Donruss Optic Dominator Signatures Gold Vinyl 18">View Details</a>
+                </div>
             </div>
             <div class="carousel-item">
                 <img src="images/2017-18/Juwan-Howard-Miami-Heat-2017-18-Panini-Panini-Flawless-Premium-Ink-Signatures-Platinum-PI-JH-sn1-front-400w.webp"
                      loading="lazy" width="400" height="550"
                      alt="2017-18 Panini Panini Flawless Premium Ink Signatures Platinum PI JH">
+                <div class="hover-overlay">
+                    <a href="cards/2017-18/Juwan-Howard-Miami-Heat-2017-18-Panini-Panini-Flawless-Premium-Ink-Signatures-Platinum-PI-JH-sn1-1240.html" class="view-button" title="View details for 2017-18 Panini Panini Flawless Premium Ink Signatures Platinum PI JH">View Details</a>
+                </div>
             </div>
             <div class="carousel-item">
                 <img src="images/2013-14/Juwan-Howard-Washington-Wizards-2013-14-Panini-Panini-Immaculate-Collection-Team-Logos-Numbers-Jersey-Patch-93-sn7-front-400w.webp"
                      loading="lazy" width="400" height="550"
                      alt="2013-14 Panini Panini Immaculate Collection Team Logos Numbers Jersey Patch 93">
+                <div class="hover-overlay">
+                    <a href="cards/2013-14/Juwan-Howard-Washington-Wizards-2013-14-Panini-Panini-Immaculate-Collection-Team-Logos-Numbers-Jersey-Patch-93-sn7-1193.html" class="view-button" title="View details for 2013-14 Panini Panini Immaculate Collection Team Logos Numbers Jersey Patch 93">View Details</a>
+                </div>
             </div>
 
             <!-- Second Set (Duplicate for seamless loop) -->
@@ -192,75 +234,120 @@ ${topNavHtml?no_esc}
                 <img src="images/1997-98/Juwan-Howard-Washington-Bullets-1997-98-Fleer-Fleer-Metal-Universe-Base-Set-Precious-Metal-Gems-Red-33-sn47-front-400w.webp"
                      loading="lazy" width="400" height="550"
                      alt="Juwan Howard 1997-98 Fleer Metal Universe Precious Metal Gems Red">
+                <div class="hover-overlay">
+                    <a href="cards/1997-98/Juwan-Howard-Washington-Bullets-1997-98-Fleer-Fleer-Metal-Universe-Base-Set-Precious-Metal-Gems-Red-33-sn47-375.html" class="view-button" title="View details for Juwan Howard 1997-98 Fleer Metal Universe Precious Metal Gems Red">View Details</a>
+                </div>
             </div>
             <div class="carousel-item">
                 <img src="images/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Fleer-Fleer-Vintage-61-Base-Set-Classic-5C-sn16-front-400w.webp"
-                     fetchpriority="high" width="400" height="550"
+                     loading="lazy" width="400" height="550"
                      alt="Juwan Howard 1998-99 Fleer Vintage 61 Base Classic 5C">
+                <div class="hover-overlay">
+                    <a href="cards/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Fleer-Fleer-Vintage-61-Base-Set-Classic-5C-sn16-509.html" class="view-button" title="View details for Juwan Howard 1998-99 Fleer Vintage 61 Base Classic 5C">View Details</a>
+                </div>
             </div>
             <div class="carousel-item">
                 <img src="images/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Fleer-Fleer-Metal-Universe-Base-Set-Precious-Metal-Gems-5-sn33-front-400w.webp"
-                     fetchpriority="high" width="400" height="550"
+                     loading="lazy" width="400" height="550"
                      alt="Juwan Howard 1998-99 Fleer Metal Universe Precious Metal Gems 5">
+                <div class="hover-overlay">
+                    <a href="cards/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Fleer-Fleer-Metal-Universe-Base-Set-Precious-Metal-Gems-5-sn33-513.html" class="view-button" title="View details for Juwan Howard 1998-99 Fleer Metal Universe Precious Metal Gems 5">View Details</a>
+                </div>
             </div>
             <div class="carousel-item">
                 <img src="images/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Fleer-Fleer-Brilliants-Base-Set-24-K-Gold-97TG-sn14-front-400w.webp"
-                     fetchpriority="high" width="400" height="550"
+                     loading="lazy" width="400" height="550"
                      alt="Juwan Howard 1998-99 Fleer Brilliants Base 24 K Gold 97TG">
+                <div class="hover-overlay">
+                    <a href="cards/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Fleer-Fleer-Brilliants-Base-Set-24-K-Gold-97TG-sn14-507.html" class="view-button" title="View details for Juwan Howard 1998-99 Fleer Brilliants Base 24 K Gold 97TG">View Details</a>
+                </div>
             </div>
             <div class="carousel-item">
                 <img src="images/2018-19/Juwan-Howard-Washington-Wizards-2018-19-Panini-Panini-Contenders-Optic-Contenders-Autographs-Gold-Vinyl-LC-JWH-sn1-front-400w.webp"
-                     fetchpriority="high" width="400" height="550"
+                     loading="lazy" width="400" height="550"
                      alt="Juwan Howard 2018-19 Panini Panini Contenders Optic Contenders Autographs Gold Vinyl LC JWH">
+                <div class="hover-overlay">
+                    <a href="cards/2018-19/Juwan-Howard-Washington-Wizards-2018-19-Panini-Panini-Contenders-Optic-Contenders-Autographs-Gold-Vinyl-LC-JWH-sn1-1266.html" class="view-button" title="View details for Juwan Howard 2018-19 Panini Panini Contenders Optic Contenders Autographs Gold Vinyl LC JWH">View Details</a>
+                </div>
             </div>
             <div class="carousel-item">
                 <img src="images/2018-19/Juwan-Howard-Washington-Wizards-2018-19-Panini-Panini-Contenders-Optic-Contenders-Autographs-Gold-Vinyl-LC-JWH-sn1-front-400w.webp"
-                     fetchpriority="high" width="400" height="550"
+                     loading="lazy" width="400" height="550"
                      alt="Juwan Howard 2018-19 Panini Panini Contenders Optic Contenders Autographs Gold Vinyl LC JWH">
+                <div class="hover-overlay">
+                    <a href="cards/2018-19/Juwan-Howard-Washington-Wizards-2018-19-Panini-Panini-Contenders-Optic-Contenders-Autographs-Gold-Vinyl-LC-JWH-sn1-1266.html" class="view-button" title="View details for Juwan Howard 2018-19 Panini Panini Contenders Optic Contenders Autographs Gold Vinyl LC JWH">View Details</a>
+                </div>
             </div>
             <div class="carousel-item">
                 <img src="images/1997-98/Juwan-Howard-Washington-Bullets-1997-98-Fleer-Fleer-Metal-Universe-Base-Set-Precious-Metal-Gems-Green-33-sn7-front-400w.webp"
                      loading="lazy" width="400" height="550"
                      alt="Juwan Howard 1997-98 Fleer Metal Universe Precious Metal Gems Green">
+                <div class="hover-overlay">
+                    <a href="cards/1997-98/Juwan-Howard-Washington-Bullets-1997-98-Fleer-Fleer-Metal-Universe-Base-Set-Precious-Metal-Gems-Green-33-sn7-376.html" class="view-button" title="View details for Juwan Howard 1997-98 Fleer Metal Universe Precious Metal Gems Green">View Details</a>
+                </div>
             </div>
             <div class="carousel-item">
                 <img src="images/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Upper-Deck-SPx-Finite-Base-Set-Spectrum-76-sn291-front-400w.webp"
                      loading="lazy" width="400" height="550" alt="Juwan Howard 1998-99 SPx Finite Base Spectrum">
+                <div class="hover-overlay">
+                    <a href="cards/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Upper-Deck-SPx-Finite-Base-Set-Spectrum-76-sn291-537.html" class="view-button" title="View details for Juwan Howard 1998-99 SPx Finite Base Spectrum">View Details</a>
+                </div>
             </div>
             <div class="carousel-item">
                 <img src="images/1997-98/Juwan-Howard-Washington-Wizards-1997-98-Fleer-Fleer-Metal-Universe-Championship-Base-Set-Precious-Metal-Gems-11-sn32-front-400w.webp"
                      loading="lazy" width="400" height="550"
                      alt="1997-98 Fleer Metal Universe Championship Precious Metal Gems 11">
+                <div class="hover-overlay">
+                    <a href="cards/1997-98/Juwan-Howard-Washington-Wizards-1997-98-Fleer-Fleer-Metal-Universe-Championship-Base-Set-Precious-Metal-Gems-11-sn32-371.html" class="view-button" title="View details for 1997-98 Fleer Metal Universe Championship Precious Metal Gems 11">View Details</a>
+                </div>
             </div>
             <div class="carousel-item">
                 <img src="images/2022-23/Juwan-Howard-Washington-Wizards-2022-23-Panini-Panini-Spectra-Icons-Autographs-Nebula-IA-JUW-sn1-front-400w.webp"
                      loading="lazy" width="400" height="550"
                      alt="2022-23 Panini Panini Spectra Icons Autographs Nebula IA JUW">
+                <div class="hover-overlay">
+                    <a href="cards/2022-23/Juwan-Howard-Washington-Wizards-2022-23-Panini-Panini-Spectra-Icons-Autographs-Nebula-IA-JUW-sn1-1348.html" class="view-button" title="View details for 2022-23 Panini Panini Spectra Icons Autographs Nebula IA JUW">View Details</a>
+                </div>
             </div>
             <div class="carousel-item">
                 <img src="images/2018-19/Juwan-Howard-Miami-Heat-2018-19-Panini-Panini-Flawless-Legendary-Scripts-Platinum-LS-JWH-sn1-front-400w.webp"
                      loading="lazy" width="400" height="550"
                      alt="2018-19 Panini Panini Flawless Legendary Scripts Platinum LS JWH">
+                <div class="hover-overlay">
+                    <a href="cards/2018-19/Juwan-Howard-Miami-Heat-2018-19-Panini-Panini-Flawless-Legendary-Scripts-Platinum-LS-JWH-sn1-1245.html" class="view-button" title="View details for 2018-19 Panini Panini Flawless Legendary Scripts Platinum LS JWH">View Details</a>
+                </div>
             </div>
             <div class="carousel-item">
                 <img src="images/2016-17/Juwan-Howard-Miami-Heat-2016-17-Panini-Panini-Donruss-Elite-Signatures-Black-99-sn1-front-400w.webp"
                      loading="lazy" width="400" height="550"
                      alt="2016-17 Panini Panini Donruss Elite Signatures Black 99">
+                <div class="hover-overlay">
+                    <a href="cards/2016-17/Juwan-Howard-Miami-Heat-2016-17-Panini-Panini-Donruss-Elite-Signatures-Black-99-sn1-1205.html" class="view-button" title="View details for 2016-17 Panini Panini Donruss Elite Signatures Black 99">View Details</a>
+                </div>
             </div>
             <div class="carousel-item">
                 <img src="images/2017-18/Juwan-Howard-Dallas-Mavericks-2017-18-Panini-Panini-Donruss-Optic-Dominator-Signatures-Gold-Vinyl-18-sn1-front-400w.webp"
                      loading="lazy" width="400" height="550"
                      alt="2017-18 Panini Panini Donruss Optic Dominator Signatures Gold Vinyl 18">
+                <div class="hover-overlay">
+                    <a href="cards/2017-18/Juwan-Howard-Dallas-Mavericks-2017-18-Panini-Panini-Donruss-Optic-Dominator-Signatures-Gold-Vinyl-18-sn1-1236.html" class="view-button" title="View details for 2017-18 Panini Panini Donruss Optic Dominator Signatures Gold Vinyl 18">View Details</a>
+                </div>
             </div>
             <div class="carousel-item">
                 <img src="images/2017-18/Juwan-Howard-Miami-Heat-2017-18-Panini-Panini-Flawless-Premium-Ink-Signatures-Platinum-PI-JH-sn1-front-400w.webp"
                      loading="lazy" width="400" height="550"
                      alt="2017-18 Panini Panini Flawless Premium Ink Signatures Platinum PI JH">
+                <div class="hover-overlay">
+                    <a href="cards/2017-18/Juwan-Howard-Miami-Heat-2017-18-Panini-Panini-Flawless-Premium-Ink-Signatures-Platinum-PI-JH-sn1-1240.html" class="view-button" title="View details for 2017-18 Panini Panini Flawless Premium Ink Signatures Platinum PI JH">View Details</a>
+                </div>
             </div>
             <div class="carousel-item">
                 <img src="images/2013-14/Juwan-Howard-Washington-Wizards-2013-14-Panini-Panini-Immaculate-Collection-Team-Logos-Numbers-Jersey-Patch-93-sn7-front-400w.webp"
                      loading="lazy" width="400" height="550"
                      alt="2013-14 Panini Panini Immaculate Collection Team Logos Numbers Jersey Patch 93">
+                <div class="hover-overlay">
+                    <a href="cards/2013-14/Juwan-Howard-Washington-Wizards-2013-14-Panini-Panini-Immaculate-Collection-Team-Logos-Numbers-Jersey-Patch-93-sn7-1193.html" class="view-button" title="View details for 2013-14 Panini Panini Immaculate Collection Team Logos Numbers Jersey Patch 93">View Details</a>
+                </div>
             </div>
         </section>
     </div>


### PR DESCRIPTION
I have enhanced the image carousel on the landing page (index.html) by adding a quick link for every card that allows users to jump directly to the card's individual detail page. 

Following the project's design and requirements:
1.  **Hover Effect:** A subtle dark overlay with a "View Details" button now appears when a user hovers over any card in the carousel. This maintains the clean default look while providing a clear interaction affordance.
2.  **Architectural Consistency:** All CSS for the new hover effects and buttons was added to `src/main/resources/css/main.css` as requested, keeping the `index.ftlh` template clean.
3.  **Correct Links:** I verified and mapped the correct relative paths for all 14 unique cards featured in the carousel, ensuring that clicking the button takes the user to the precise detail page for that card.
4.  **Seamless Loop Maintenance:** Both the primary set and the duplicate set of carousel items were updated to ensure the infinite scrolling animation remains smooth and functional.
5.  **Verified:** The changes were verified both by automated tests and visual inspection via a Playwright script recording the hover and navigation behavior.

---
*PR created automatically by Jules for task [8451528022838207666](https://jules.google.com/task/8451528022838207666) started by @AndreasBild*