### PR TITLE
Implement Scroll Restoration for Card Collection Overview

### DIFF
--- a/src/main/java/de/maulmann/CardPageGenerator.java
+++ b/src/main/java/de/maulmann/CardPageGenerator.java
@@ -297,6 +297,7 @@ public class CardPageGenerator {
                                 .findFirst().orElse(null);
 
                         if (matchingCard != null) {
+                            row.attr("id", matchingCard.filenameBase);
                             String originalText = playerCell.text();
                             playerCell.empty();
                             playerCell.appendElement("a")

--- a/src/main/resources/templates/card-detail.ftlh
+++ b/src/main/resources/templates/card-detail.ftlh
@@ -15,7 +15,7 @@
 ${topNavHtml?no_esc}
 
 <nav class="detail-nav no-border-bg">
-    <a href="../../${overviewPage}" class="modern-button no-text-decoration">&larr; Overview</a>
+    <a id="backToOverview" href="../../${overviewPage}" class="modern-button no-text-decoration">&larr; Overview</a>
     <div class="nav-button-group">
         <#if prevLink??>
             <a id="prevCardLink" href="${prevLink}" class="modern-button no-text-decoration">&laquo; Prev</a>
@@ -207,6 +207,19 @@ ${topNavHtml?no_esc}
     window.onclick = function (event) {
         if (event.target == modal) closeModal();
     }
+
+    document.addEventListener('DOMContentLoaded', () => {
+        // Extract card ID from filename
+        const pathParts = window.location.pathname.split('/');
+        const filename = pathParts[pathParts.length - 1];
+        if (filename && filename.endsWith('.html')) {
+            const cardId = filename.replace('.html', '');
+            const backLink = document.getElementById('backToOverview');
+            if (backLink) {
+                backLink.href += '#' + cardId;
+            }
+        }
+    });
     document.addEventListener('keydown', function (event) {
         if (event.key === "Escape") closeModal();
         if (event.key === "ArrowLeft") {

--- a/src/main/resources/templates/collection-overview.ftlh
+++ b/src/main/resources/templates/collection-overview.ftlh
@@ -165,6 +165,22 @@ ${topNavHtml?no_esc}
             }
 
             document.addEventListener('DOMContentLoaded', () => {
+                // --- Scroll Restoration Logic ---
+                const savedCardId = sessionStorage.getItem('lastClickedCard');
+                if (savedCardId) {
+                    const targetRow = document.getElementById(savedCardId);
+                    if (targetRow) {
+                        setTimeout(() => {
+                            targetRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                            targetRow.style.backgroundColor = '#ffffcc';
+                            setTimeout(() => {
+                                targetRow.style.backgroundColor = '';
+                            }, 2000);
+                        }, 100);
+                    }
+                    sessionStorage.removeItem('lastClickedCard');
+                }
+
                 document.querySelectorAll('.season-table-wrapper table').forEach(table => {
                     const headers = table.querySelectorAll('th');
                     headers.forEach((header, index) => {
@@ -208,6 +224,14 @@ ${topNavHtml?no_esc}
                             rowArray.forEach(row => tbody.appendChild(row));
                             sortAsc = !sortAsc;
                         });
+                    });
+
+                    // Capture click for scroll restoration
+                    table.addEventListener('click', (e) => {
+                        const row = e.target.closest('tr');
+                        if (row && row.id) {
+                            sessionStorage.setItem('lastClickedCard', row.id);
+                        }
                     });
                 });
             });

--- a/src/main/resources/templates/generic-collection.ftlh
+++ b/src/main/resources/templates/generic-collection.ftlh
@@ -11,6 +11,37 @@ ${topNavHtml?no_esc}
         ${pageContent?no_esc}
     </div>
 </main>
+
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        // --- Scroll Restoration Logic ---
+        const savedCardId = sessionStorage.getItem('lastClickedCard');
+        if (savedCardId) {
+            const targetRow = document.getElementById(savedCardId);
+            if (targetRow) {
+                setTimeout(() => {
+                    targetRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                    targetRow.style.backgroundColor = '#ffffcc';
+                    setTimeout(() => {
+                        targetRow.style.backgroundColor = '';
+                    }, 2000);
+                }, 100);
+            }
+            sessionStorage.removeItem('lastClickedCard');
+        }
+
+        document.querySelectorAll('.collection-table-wrapper table').forEach(table => {
+            // Capture click for scroll restoration
+            table.addEventListener('click', (e) => {
+                const row = e.target.closest('tr');
+                if (row && row.id) {
+                    sessionStorage.setItem('lastClickedCard', row.id);
+                }
+            });
+        });
+    });
+</script>
+
 ${footerHtml?no_esc}
 </body>
 </html>


### PR DESCRIPTION
This feature improves the user experience when navigating between the card collection overview and individual card detail pages. 

Key changes:
1.  **Row Identification:** `CardPageGenerator.java` now adds an `id` attribute to each row in the collection tables, using the card's unique filename base.
2.  **Scroll Position Preservation:**
    *   Added logic to `collection-overview.ftlh` and `generic-collection.ftlh` that saves the ID of a clicked card row to `sessionStorage`.
    *   On page load, if a saved ID exists, the page smoothly scrolls to that row and highlights it with a light yellow background for 2 seconds.
3.  **Fallback Navigation:** `card-detail.ftlh` now dynamically appends the current card's ID as a hash fragment to the "Overview" button link, providing a native browser fallback for scroll restoration.

This ensures that users can browse long tables, view a card's details, and return exactly to where they were without manual scrolling.

---
*PR created automatically by Jules for task [11101838143498193706](https://jules.google.com/task/11101838143498193706) started by @AndreasBild*