### PR TITLE
Fix 1/1 Trivia Display

### DIFF
--- a/src/main/java/de/maulmann/TriviaManager.java
+++ b/src/main/java/de/maulmann/TriviaManager.java
@@ -43,23 +43,32 @@ public class TriviaManager {
             Map.Entry<String, JsonNode> entry = fields.next();
             String fullKey = entry.getKey();
 
-            // Handle logical variants like "Variant!", "Variant_2"
+            // Handle logical variants like "Variant!", "Variant_2", "Serial="
             String baseKey = fullKey;
             boolean negate = false;
+            boolean exact = false;
 
             if (fullKey.endsWith("!")) {
                 baseKey = fullKey.substring(0, fullKey.length() - 1);
                 negate = true;
+            } else if (fullKey.endsWith("=")) {
+                baseKey = fullKey.substring(0, fullKey.length() - 1);
+                exact = true;
             }
+
             if (baseKey.contains("_")) {
                 baseKey = baseKey.split("_")[0];
             }
 
-            String cardValue = cardData.getOrDefault(baseKey, "").toLowerCase();
-            String conditionValue = entry.getValue().asText().toLowerCase();
+            String cardValue = cardData.getOrDefault(baseKey, "").trim().toLowerCase();
+            String conditionValue = entry.getValue().asText().trim().toLowerCase();
 
             if (negate) {
                 if (cardValue.contains(conditionValue)) {
+                    return false;
+                }
+            } else if (exact) {
+                if (!cardValue.equals(conditionValue)) {
                     return false;
                 }
             } else {

--- a/src/main/resources/config/trivia_config.json
+++ b/src/main/resources/config/trivia_config.json
@@ -151,6 +151,10 @@
       "text": "<strong>One-of-One (1/1):</strong> This card is a true Masterpiece. Being the absolute only card of its exact kind ever manufactured makes it the ultimate crown jewel for any serious collector."
     },
     {
+      "condition": { "Serial=": "1", "Print Run=": "1" },
+      "text": "<strong>One-of-One (1/1):</strong> This card is a true Masterpiece. Being the absolute only card of its exact kind ever manufactured makes it the ultimate crown jewel for any serious collector."
+    },
+    {
       "condition": { "Variant": "masterpiece" },
       "text": "<strong>One-of-One (1/1):</strong> This card is a true Masterpiece. Being the absolute only card of its exact kind ever manufactured makes it the ultimate crown jewel for any serious collector."
     },


### PR DESCRIPTION
The trivia for "1/1" cards was failing to display when the source data used separate "Serial" and "Print Run" columns (both containing "1") instead of a combined "Serial/Print Run" column (containing "1/1"). 

This change improves the `TriviaManager` matching engine by:
1. Adding support for exact matching using an `=` suffix in configuration keys (e.g., `"Serial=": "1"`). This prevents false positives like matching "1" with "10".
2. Making the matching whitespace-robust by applying `.trim()` to both card data and condition values.
3. Updating `trivia_config.json` with a specific rule that checks for both `Serial` and `Print Run` being exactly "1".

Verified the fix by rebuilding the site and confirming the "One-of-One" trivia appears on relevant card detail pages.

---
*PR created automatically by Jules for task [15798560054849426541](https://jules.google.com/task/15798560054849426541) started by @AndreasBild*