### PR TITLE
Implement Brotli compression for web assets

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,16 @@
             <version>${org.junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.aayushatharva.brotli4j</groupId>
+            <artifactId>brotli4j</artifactId>
+            <version>1.16.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.aayushatharva.brotli4j</groupId>
+            <artifactId>native-linux-x86_64</artifactId>
+            <version>1.16.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/de/maulmann/BrotliCompressor.java
+++ b/src/main/java/de/maulmann/BrotliCompressor.java
@@ -1,0 +1,58 @@
+package de.maulmann;
+
+import com.aayushatharva.brotli4j.Brotli4jLoader;
+import com.aayushatharva.brotli4j.encoder.BrotliOutputStream;
+import com.aayushatharva.brotli4j.encoder.Encoder;
+
+import java.io.*;
+import java.nio.file.Files;
+
+public class BrotliCompressor {
+
+    static {
+        Brotli4jLoader.ensureAvailability();
+    }
+
+    // Default compression level for Brotli (usually 4 is a good balance, but let's use 11 for "best" as requested by context of 9 in GZIP)
+    public static final int DEFAULT_QUALITY = 4;
+    public static final int BEST_QUALITY = 11;
+
+    // --- 1. File-to-File Method ---
+    public static void compressFile(File inputFile, File outputFile, int quality) throws IOException {
+        Encoder.Parameters params = new Encoder.Parameters().setQuality(quality);
+        try (InputStream in = Files.newInputStream(inputFile.toPath());
+             OutputStream out = Files.newOutputStream(outputFile.toPath());
+             BrotliOutputStream brOut = new BrotliOutputStream(out, params)) {
+
+            byte[] buffer = new byte[65536];
+            int len;
+            while ((len = in.read(buffer)) != -1) {
+                brOut.write(buffer, 0, len);
+            }
+        }
+    }
+
+    // --- 2. RAM-to-File Method ---
+    public static void compressBytesToFile(byte[] inputData, File outputFile, int quality) throws IOException {
+        Encoder.Parameters params = new Encoder.Parameters().setQuality(quality);
+        try (OutputStream out = Files.newOutputStream(outputFile.toPath());
+             BrotliOutputStream brOut = new BrotliOutputStream(out, params)) {
+            brOut.write(inputData);
+        }
+    }
+
+    // --- 3. Pure In-Memory Method ---
+    public static byte[] compressBytes(byte[] inputData, int quality) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        Encoder.Parameters params = new Encoder.Parameters().setQuality(quality);
+        try (BrotliOutputStream brOut = new BrotliOutputStream(baos, params)) {
+            brOut.write(inputData);
+        }
+        return baos.toByteArray();
+    }
+
+    // Default override
+    public static void compressFile(File inputFile, File outputFile) throws IOException {
+        compressFile(inputFile, outputFile, DEFAULT_QUALITY);
+    }
+}

--- a/src/main/java/de/maulmann/CSSMinifier.java
+++ b/src/main/java/de/maulmann/CSSMinifier.java
@@ -21,7 +21,7 @@ public class CSSMinifier {
     }
 
     // --- NEW: IN-MEMORY METHOD ---
-    // Use this to pass data directly to your GZIP compressor without touching the disk!
+    // Use this to pass data directly to your Brotli compressor without touching the disk!
     public static byte[] minifyCSSToBytes(File inputFile) throws IOException {
         try (Reader in = new InputStreamReader(Files.newInputStream(inputFile.toPath()), StandardCharsets.UTF_8);
              StringWriter out = new StringWriter()) {

--- a/src/main/java/de/maulmann/HTMLMinifier.java
+++ b/src/main/java/de/maulmann/HTMLMinifier.java
@@ -27,7 +27,7 @@ public class HTMLMinifier {
     }
 
     // --- NEW: IN-MEMORY METHOD ---
-    // Use this to pass data directly to your GZIP compressor without touching the disk!
+    // Use this to pass data directly to your Brotli compressor without touching the disk!
     public static byte[] minifyHTMLToBytes(File inputFile) throws IOException {
         Document document = Jsoup.parse(inputFile, "UTF-8");
         document.outputSettings().prettyPrint(false);

--- a/src/main/java/de/maulmann/SiteBuilderPipeline.java
+++ b/src/main/java/de/maulmann/SiteBuilderPipeline.java
@@ -86,7 +86,7 @@ public class SiteBuilderPipeline {
             System.out.println("\n[PHASE 3] Minifying, Compressing, and Uploading Web Files...");
             processAndUploadWebFiles(s3AsyncClient, tracker);
 
-            // --- PHASE 4: Upload Images (No GZIP) ---
+            // --- PHASE 4: Upload Images (No Compression) ---
             System.out.println("\n[PHASE 4] Syncing Images to S3...");
             processAndUploadImages(s3AsyncClient, tracker);
 
@@ -142,25 +142,25 @@ public class SiteBuilderPipeline {
                     CompletableFuture<Void> uploadTask = null;
 
                     if (fileName.endsWith(".html")) {
-                        byte[] gzippedData = GZIPCompressor.compressBytes(HTMLMinifier.minifyHTMLToBytes(file.toFile()), 9);
-                        uploadTask = uploadBytesAsync(s3Client, s3Key, gzippedData, "text/html", CACHE_SHORT, uploadCount);
+                        byte[] brData = BrotliCompressor.compressBytes(HTMLMinifier.minifyHTMLToBytes(file.toFile()), BrotliCompressor.BEST_QUALITY);
+                        uploadTask = uploadBytesAsync(s3Client, s3Key, brData, "text/html", "br", CACHE_SHORT, uploadCount);
                     } else if (fileName.endsWith(".css")) {
-                        byte[] gzippedData = GZIPCompressor.compressBytes(CSSMinifier.minifyCSSToBytes(file.toFile()), 9);
-                        uploadTask = uploadBytesAsync(s3Client, s3Key, gzippedData, "text/css", CACHE_LONG, uploadCount);
+                        byte[] brData = BrotliCompressor.compressBytes(CSSMinifier.minifyCSSToBytes(file.toFile()), BrotliCompressor.BEST_QUALITY);
+                        uploadTask = uploadBytesAsync(s3Client, s3Key, brData, "text/css", "br", CACHE_LONG, uploadCount);
                     } else if (fileName.endsWith(".js")) {
-                        byte[] gzippedData = GZIPCompressor.compressBytes(Files.readAllBytes(file), 9);
-                        uploadTask = uploadBytesAsync(s3Client, s3Key, gzippedData, "application/javascript", CACHE_LONG, uploadCount);
+                        byte[] brData = BrotliCompressor.compressBytes(Files.readAllBytes(file), BrotliCompressor.BEST_QUALITY);
+                        uploadTask = uploadBytesAsync(s3Client, s3Key, brData, "application/javascript", "br", CACHE_LONG, uploadCount);
                     } else if (fileName.endsWith(".json")) {
-                        byte[] gzippedData = GZIPCompressor.compressBytes(Files.readAllBytes(file), 9);
-                        uploadTask = uploadBytesAsync(s3Client, s3Key, gzippedData, "application/json", CACHE_SHORT, uploadCount);
+                        byte[] brData = BrotliCompressor.compressBytes(Files.readAllBytes(file), BrotliCompressor.BEST_QUALITY);
+                        uploadTask = uploadBytesAsync(s3Client, s3Key, brData, "application/json", "br", CACHE_SHORT, uploadCount);
                     } else if (fileName.endsWith(".xml")) {
                         byte[] gzippedData = GZIPCompressor.compressBytes(Files.readAllBytes(file), 9);
-                        uploadTask = uploadBytesAsync(s3Client, s3Key, gzippedData, "application/xml", CACHE_SHORT, uploadCount);
+                        uploadTask = uploadBytesAsync(s3Client, s3Key, gzippedData, "application/xml", "gzip", CACHE_SHORT, uploadCount);
                     } else if (fileName.endsWith(".ico")) {
                         uploadTask = uploadRawFileAsync(s3Client, file, s3Key, "image/x-icon", CACHE_LONG, uploadCount);
                     } else if (fileName.startsWith("robots")) {
-                        byte[] gzippedData = GZIPCompressor.compressBytes(Files.readAllBytes(file), 9);
-                        uploadTask = uploadBytesAsync(s3Client, s3Key, gzippedData, "text/plain", CACHE_SHORT, uploadCount);
+                        byte[] brData = BrotliCompressor.compressBytes(Files.readAllBytes(file), BrotliCompressor.BEST_QUALITY);
+                        uploadTask = uploadBytesAsync(s3Client, s3Key, brData, "text/plain", "br", CACHE_SHORT, uploadCount);
                     }
 
                     // Nach erfolgreichem Upload: Hash aktualisieren
@@ -355,12 +355,12 @@ public class SiteBuilderPipeline {
         }
     }
 
-    private static CompletableFuture<Void> uploadBytesAsync(S3AsyncClient s3Client, String s3Key, byte[] data, String contentType, String cacheControl, AtomicInteger counter) {
+    private static CompletableFuture<Void> uploadBytesAsync(S3AsyncClient s3Client, String s3Key, byte[] data, String contentType, String contentEncoding, String cacheControl, AtomicInteger counter) {
         PutObjectRequest request = PutObjectRequest.builder()
                 .bucket(BUCKET_NAME)
                 .key(s3Key)
                 .contentType(contentType)
-                .contentEncoding("gzip")
+                .contentEncoding(contentEncoding)
                 .contentLanguage("en-US")
                 .cacheControl(cacheControl)
                 .build();

--- a/src/test/java/de/maulmann/BrotliCompressorTest.java
+++ b/src/test/java/de/maulmann/BrotliCompressorTest.java
@@ -1,0 +1,81 @@
+package de.maulmann;
+
+import com.aayushatharva.brotli4j.decoder.BrotliInputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BrotliCompressorTest {
+
+    @TempDir
+    Path tempDir;
+
+    private String readBrotliFile(Path filePath) throws IOException {
+        StringBuilder content = new StringBuilder();
+        try (FileInputStream fis = new FileInputStream(filePath.toFile());
+             BrotliInputStream bis = new BrotliInputStream(fis);
+             InputStreamReader isr = new InputStreamReader(bis);
+             BufferedReader br = new BufferedReader(isr)) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                content.append(line);
+            }
+        }
+        return content.toString();
+    }
+
+    @Test
+    void testCompressFile() throws IOException {
+        Path sourceFile = tempDir.resolve("testCompress.txt");
+        Path outputFile = tempDir.resolve("testCompress.txt.br");
+        String originalContent = "This is a test string for Brotli compression. " +
+                                 "It needs to be long enough to demonstrate effective compression. " +
+                                 "Repeating some content helps with compression ratios. " +
+                                 "Test test test test test.";
+        Files.write(sourceFile, originalContent.getBytes());
+
+        // Test with default quality
+        BrotliCompressor.compressFile(sourceFile.toFile(), outputFile.toFile());
+
+        assertTrue(Files.exists(outputFile), "Compressed file should exist.");
+        String decompressedContent = readBrotliFile(outputFile);
+        assertEquals(originalContent, decompressedContent, "Decompressed content should match original.");
+        assertTrue(Files.size(outputFile) < Files.size(sourceFile), "Compressed file should be smaller than original for this content.");
+
+        Files.delete(outputFile);
+
+        // Test with specific quality (BEST_QUALITY)
+        Path outputFileBest = tempDir.resolve("testCompressBest.txt.br");
+        BrotliCompressor.compressFile(sourceFile.toFile(), outputFileBest.toFile(), BrotliCompressor.BEST_QUALITY);
+        assertTrue(Files.exists(outputFileBest), "Compressed file (best quality) should exist.");
+        String decompressedContentBest = readBrotliFile(outputFileBest);
+        assertEquals(originalContent, decompressedContentBest, "Decompressed content (best quality) should match original.");
+        assertTrue(Files.size(outputFileBest) < Files.size(sourceFile), "Compressed file (best quality) should be smaller.");
+    }
+
+    @Test
+    void testCompressBytes() throws IOException {
+        String originalContent = "Brotli byte compression test content.";
+        byte[] inputData = originalContent.getBytes();
+
+        byte[] compressedData = BrotliCompressor.compressBytes(inputData, BrotliCompressor.DEFAULT_QUALITY);
+
+        assertTrue(compressedData.length > 0, "Compressed data should not be empty.");
+
+        try (BrotliInputStream bis = new BrotliInputStream(new ByteArrayInputStream(compressedData));
+             ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            byte[] buffer = new byte[1024];
+            int len;
+            while ((len = bis.read(buffer)) != -1) {
+                baos.write(buffer, 0, len);
+            }
+            assertEquals(originalContent, baos.toString(), "Decompressed bytes should match original content.");
+        }
+    }
+}


### PR DESCRIPTION
This change replaces GZIP compression with Brotli compression for most static web assets (HTML, CSS, JS, JSON, robots.txt) to improve delivery performance. Per user request, sitemaps (XML files) continue to use GZIP compression. The S3 upload process has been updated to set the correct `Content-Encoding` metadata (`br` for Brotli, `gzip` for GZIP) while maintaining the original `Content-Type`, ensuring that browsers can correctly decompress and render the files. New unit tests have been added for the Brotli implementation, and existing tests have been verified.

---
*PR created automatically by Jules for task [15774478107552629424](https://jules.google.com/task/15774478107552629424) started by @AndreasBild*