### PR TITLE
Fix broken links in index.ftlh carousel

### DIFF
--- a/src/main/resources/templates/index.ftlh
+++ b/src/main/resources/templates/index.ftlh
@@ -123,7 +123,7 @@ ${topNavHtml?no_esc}
                      alt="Juwan Howard 1997-98 Fleer Metal Universe Precious Metal Gems Red"
                      title="Juwan Howard Private Collection - 1997-98 PMG Red">
                 <div class="hover-overlay">
-                    <a href="cards/1997-98/Juwan-Howard-Washington-Bullets-1997-98-Fleer-Fleer-Metal-Universe-Base-Set-Precious-Metal-Gems-Red-33-PMG-sn47-375.html" class="view-button" title="View details for Juwan Howard 1997-98 Fleer Metal Universe Precious Metal Gems Red">View Details</a>
+                    <a href="cards/1997-98/Juwan-Howard-Washington-Bullets-1997-98-Fleer-Fleer-Metal-Universe-Base-Set-Precious-Metal-Gems-Red-33-PMG-sn47-f82795b8.html" class="view-button" title="View details for Juwan Howard 1997-98 Fleer Metal Universe Precious Metal Gems Red">View Details</a>
                 </div>
             </div>
             <div class="carousel-item">
@@ -132,7 +132,7 @@ ${topNavHtml?no_esc}
                      alt="Juwan Howard 1998-99 Fleer Vintage 61 Base Classic 5C"
                      title="Juwan Howard Private Collection - 1998-99 Fleer Vintage 61">
                 <div class="hover-overlay">
-                    <a href="cards/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Fleer-Fleer-Vintage-61-Base-Set-Classic-5C-sn16-509.html" class="view-button" title="View details for Juwan Howard 1998-99 Fleer Vintage 61 Base Classic 5C">View Details</a>
+                    <a href="cards/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Fleer-Fleer-Vintage-61-Base-Set-Classic-5C-sn16-6de9ac17.html" class="view-button" title="View details for Juwan Howard 1998-99 Fleer Vintage 61 Base Classic 5C">View Details</a>
                 </div>
             </div>
             <div class="carousel-item">
@@ -141,7 +141,7 @@ ${topNavHtml?no_esc}
                      alt="Juwan Howard 1998-99 Fleer Metal Universe Precious Metal Gems 5"
                      title="Juwan Howard Private Collection - 1998-99 PMG">
                 <div class="hover-overlay">
-                    <a href="cards/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Fleer-Fleer-Metal-Universe-Base-Set-Precious-Metal-Gems-5-sn33-513.html" class="view-button" title="View details for Juwan Howard 1998-99 Fleer Metal Universe Precious Metal Gems 5">View Details</a>
+                    <a href="cards/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Fleer-Fleer-Metal-Universe-Base-Set-Precious-Metal-Gems-5-sn33-202e3390.html" class="view-button" title="View details for Juwan Howard 1998-99 Fleer Metal Universe Precious Metal Gems 5">View Details</a>
                 </div>
             </div>
             <div class="carousel-item">
@@ -150,7 +150,7 @@ ${topNavHtml?no_esc}
                      alt="Juwan Howard 1998-99 Fleer Brilliants Base 24 K Gold 97TG"
                      title="Juwan Howard Private Collection - 1998-99 Fleer Brilliants 24K Gold">
                 <div class="hover-overlay">
-                    <a href="cards/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Fleer-Fleer-Brilliants-Base-Set-24-K-Gold-97TG-sn14-507.html" class="view-button" title="View details for Juwan Howard 1998-99 Fleer Brilliants Base 24 K Gold 97TG">View Details</a>
+                    <a href="cards/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Fleer-Fleer-Brilliants-Base-Set-24-K-Gold-97TG-sn14-d253d68b.html" class="view-button" title="View details for Juwan Howard 1998-99 Fleer Brilliants Base 24 K Gold 97TG">View Details</a>
                 </div>
             </div>
             <div class="carousel-item">
@@ -159,7 +159,7 @@ ${topNavHtml?no_esc}
                      alt="Juwan Howard 2018-19 Panini Panini Contenders Optic Contenders Autographs Gold Vinyl LC JWH"
                      title="Juwan Howard Private Collection - 2018-19 Contenders Optic Gold Vinyl 1/1">
                 <div class="hover-overlay">
-                    <a href="cards/2018-19/Juwan-Howard-Washington-Wizards-2018-19-Panini-Panini-Contenders-Optic-Contenders-Autographs-Gold-Vinyl-LC-JWH-sn1-1266.html" class="view-button" title="View details for Juwan Howard 2018-19 Panini Panini Contenders Optic Contenders Autographs Gold Vinyl LC JWH">View Details</a>
+                    <a href="cards/2018-19/Juwan-Howard-Washington-Wizards-2018-19-Panini-Panini-Contenders-Optic-Contenders-Autographs-Gold-Vinyl-LC-JWH-sn1-e49f9113.html" class="view-button" title="View details for Juwan Howard 2018-19 Panini Panini Contenders Optic Contenders Autographs Gold Vinyl LC JWH">View Details</a>
                 </div>
             </div>
             <div class="carousel-item">
@@ -168,7 +168,7 @@ ${topNavHtml?no_esc}
                      alt="Juwan Howard 1997-98 Fleer Metal Universe Precious Metal Gems Green"
                      title="Juwan Howard Private Collection - 1997-98 PMG Green 1/10">
                 <div class="hover-overlay">
-                    <a href="cards/1997-98/Juwan-Howard-Washington-Bullets-1997-98-Fleer-Fleer-Metal-Universe-Base-Set-Precious-Metal-Gems-Green-33-PMG-sn7-376.html" class="view-button" title="View details for Juwan Howard 1997-98 Fleer Metal Universe Precious Metal Gems Green">View Details</a>
+                    <a href="cards/1997-98/Juwan-Howard-Washington-Bullets-1997-98-Fleer-Fleer-Metal-Universe-Base-Set-Precious-Metal-Gems-Green-33-PMG-sn7-036109be.html" class="view-button" title="View details for Juwan Howard 1997-98 Fleer Metal Universe Precious Metal Gems Green">View Details</a>
                 </div>
             </div>
             <div class="carousel-item">
@@ -176,7 +176,7 @@ ${topNavHtml?no_esc}
                      loading="lazy" width="400" height="550" alt="Juwan Howard 1998-99 SPx Finite Base Spectrum"
                      title="Juwan Howard Private Collection - 1998-99 SPx Finite Spectrum">
                 <div class="hover-overlay">
-                    <a href="cards/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Upper-Deck-SPx-Finite-Base-Set-Spectrum-76-sn291-537.html" class="view-button" title="View details for Juwan Howard 1998-99 SPx Finite Base Spectrum">View Details</a>
+                    <a href="cards/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Upper-Deck-SPx-Finite-Base-Set-Spectrum-76-sn291-0dd7be42.html" class="view-button" title="View details for Juwan Howard 1998-99 SPx Finite Base Spectrum">View Details</a>
                 </div>
             </div>
             <div class="carousel-item">
@@ -185,7 +185,7 @@ ${topNavHtml?no_esc}
                      alt="1997-98 Fleer Metal Universe Championship Precious Metal Gems 11"
                      title="Juwan Howard Private Collection - 1997-98 PMG Championship">
                 <div class="hover-overlay">
-                    <a href="cards/1997-98/Juwan-Howard-Washington-Wizards-1997-98-Fleer-Fleer-Metal-Universe-Championship-Base-Set-Precious-Metal-Gems-11-sn32-371.html" class="view-button" title="View details for 1997-98 Fleer Metal Universe Championship Precious Metal Gems 11">View Details</a>
+                    <a href="cards/1997-98/Juwan-Howard-Washington-Wizards-1997-98-Fleer-Fleer-Metal-Universe-Championship-Base-Set-Precious-Metal-Gems-11-sn32-bec55345.html" class="view-button" title="View details for 1997-98 Fleer Metal Universe Championship Precious Metal Gems 11">View Details</a>
                 </div>
             </div>
             <div class="carousel-item">
@@ -194,7 +194,7 @@ ${topNavHtml?no_esc}
                      alt="2022-23 Panini Panini Spectra Icons Autographs Nebula IA JUW"
                      title="Juwan Howard Private Collection - 2022-23 Spectra Nebula 1/1">
                 <div class="hover-overlay">
-                    <a href="cards/2022-23/Juwan-Howard-Washington-Wizards-2022-23-Panini-Panini-Spectra-Icons-Autographs-Nebula-IA-JUW-sn1-1348.html" class="view-button" title="View details for 2022-23 Panini Panini Spectra Icons Autographs Nebula IA JUW">View Details</a>
+                    <a href="cards/2022-23/Juwan-Howard-Washington-Wizards-2022-23-Panini-Panini-Spectra-Icons-Autographs-Nebula-IA-JUW-sn1-e5137523.html" class="view-button" title="View details for 2022-23 Panini Panini Spectra Icons Autographs Nebula IA JUW">View Details</a>
                 </div>
             </div>
             <div class="carousel-item">
@@ -203,7 +203,7 @@ ${topNavHtml?no_esc}
                      alt="2018-19 Panini Panini Flawless Legendary Scripts Platinum LS JWH"
                      title="Juwan Howard Private Collection - 2018-19 Flawless Platinum 1/1">
                 <div class="hover-overlay">
-                    <a href="cards/2018-19/Juwan-Howard-Miami-Heat-2018-19-Panini-Panini-Flawless-Legendary-Scripts-Platinum-LS-JWH-sn1-1245.html" class="view-button" title="View details for 2018-19 Panini Panini Flawless Legendary Scripts Platinum LS JWH">View Details</a>
+                    <a href="cards/2018-19/Juwan-Howard-Miami-Heat-2018-19-Panini-Panini-Flawless-Legendary-Scripts-Platinum-LS-JWH-sn1-0a9bf98e.html" class="view-button" title="View details for 2018-19 Panini Panini Flawless Legendary Scripts Platinum LS JWH">View Details</a>
                 </div>
             </div>
             <div class="carousel-item">
@@ -212,7 +212,7 @@ ${topNavHtml?no_esc}
                      alt="2016-17 Panini Panini Donruss Elite Signatures Black 99"
                      title="Juwan Howard Private Collection - 2016-17 Donruss Elite Black 1/1">
                 <div class="hover-overlay">
-                    <a href="cards/2016-17/Juwan-Howard-Miami-Heat-2016-17-Panini-Panini-Donruss-Elite-Signatures-Black-99-sn1-1205.html" class="view-button" title="View details for 2016-17 Panini Panini Donruss Elite Signatures Black 99">View Details</a>
+                    <a href="cards/2016-17/Juwan-Howard-Miami-Heat-2016-17-Panini-Panini-Donruss-Elite-Signatures-Black-99-sn1-ea4c7783.html" class="view-button" title="View details for 2016-17 Panini Panini Donruss Elite Signatures Black 99">View Details</a>
                 </div>
             </div>
             <div class="carousel-item">
@@ -221,7 +221,7 @@ ${topNavHtml?no_esc}
                      alt="2017-18 Panini Panini Donruss Optic Dominator Signatures Gold Vinyl 18"
                      title="Juwan Howard Private Collection - 2017-18 Optic Gold Vinyl 1/1">
                 <div class="hover-overlay">
-                    <a href="cards/2017-18/Juwan-Howard-Dallas-Mavericks-2017-18-Panini-Panini-Donruss-Optic-Dominator-Signatures-Gold-Vinyl-18-sn1-1236.html" class="view-button" title="View details for 2017-18 Panini Panini Donruss Optic Dominator Signatures Gold Vinyl 18">View Details</a>
+                    <a href="cards/2017-18/Juwan-Howard-Dallas-Mavericks-2017-18-Panini-Panini-Donruss-Optic-Dominator-Signatures-Gold-Vinyl-18-sn1-a2de02d4.html" class="view-button" title="View details for 2017-18 Panini Panini Donruss Optic Dominator Signatures Gold Vinyl 18">View Details</a>
                 </div>
             </div>
             <div class="carousel-item">
@@ -230,7 +230,7 @@ ${topNavHtml?no_esc}
                      alt="2017-18 Panini Panini Flawless Premium Ink Signatures Platinum PI JH"
                      title="Juwan Howard Private Collection - 2017-18 Flawless Premium Ink 1/1">
                 <div class="hover-overlay">
-                    <a href="cards/2017-18/Juwan-Howard-Miami-Heat-2017-18-Panini-Panini-Flawless-Premium-Ink-Signatures-Platinum-PI-JH-sn1-1240.html" class="view-button" title="View details for 2017-18 Panini Panini Flawless Premium Ink Signatures Platinum PI JH">View Details</a>
+                    <a href="cards/2017-18/Juwan-Howard-Miami-Heat-2017-18-Panini-Panini-Flawless-Premium-Ink-Signatures-Platinum-PI-JH-sn1-eaf6fed5.html" class="view-button" title="View details for 2017-18 Panini Panini Flawless Premium Ink Signatures Platinum PI JH">View Details</a>
                 </div>
             </div>
             <div class="carousel-item">
@@ -239,7 +239,7 @@ ${topNavHtml?no_esc}
                      alt="2013-14 Panini Panini Immaculate Collection Team Logos Numbers Jersey Patch 93"
                      title="Juwan Howard Private Collection - 2013-14 Immaculate Patch">
                 <div class="hover-overlay">
-                    <a href="cards/2013-14/Juwan-Howard-Washington-Wizards-2013-14-Panini-Panini-Immaculate-Collection-Team-Logos-Numbers-Jersey-Patch-93-sn7-1193.html" class="view-button" title="View details for 2013-14 Panini Panini Immaculate Collection Team Logos Numbers Jersey Patch 93">View Details</a>
+                    <a href="cards/2013-14/Juwan-Howard-Washington-Wizards-2013-14-Panini-Panini-Immaculate-Collection-Team-Logos-Numbers-Jersey-Patch-93-sn7-9a8732d2.html" class="view-button" title="View details for 2013-14 Panini Panini Immaculate Collection Team Logos Numbers Jersey Patch 93">View Details</a>
                 </div>
             </div>
 
@@ -250,7 +250,7 @@ ${topNavHtml?no_esc}
                      alt="Juwan Howard 1997-98 Fleer Metal Universe Precious Metal Gems Red"
                      title="Juwan Howard Private Collection - 1997-98 PMG Red">
                 <div class="hover-overlay">
-                    <a href="cards/1997-98/Juwan-Howard-Washington-Bullets-1997-98-Fleer-Fleer-Metal-Universe-Base-Set-Precious-Metal-Gems-Red-33-PMG-sn47-375.html" class="view-button" title="View details for Juwan Howard 1997-98 Fleer Metal Universe Precious Metal Gems Red">View Details</a>
+                    <a href="cards/1997-98/Juwan-Howard-Washington-Bullets-1997-98-Fleer-Fleer-Metal-Universe-Base-Set-Precious-Metal-Gems-Red-33-PMG-sn47-f82795b8.html" class="view-button" title="View details for Juwan Howard 1997-98 Fleer Metal Universe Precious Metal Gems Red">View Details</a>
                 </div>
             </div>
             <div class="carousel-item">
@@ -259,7 +259,7 @@ ${topNavHtml?no_esc}
                      alt="Juwan Howard 1998-99 Fleer Vintage 61 Base Classic 5C"
                      title="Juwan Howard Private Collection - 1998-99 Fleer Vintage 61">
                 <div class="hover-overlay">
-                    <a href="cards/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Fleer-Fleer-Vintage-61-Base-Set-Classic-5C-sn16-509.html" class="view-button" title="View details for Juwan Howard 1998-99 Fleer Vintage 61 Base Classic 5C">View Details</a>
+                    <a href="cards/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Fleer-Fleer-Vintage-61-Base-Set-Classic-5C-sn16-6de9ac17.html" class="view-button" title="View details for Juwan Howard 1998-99 Fleer Vintage 61 Base Classic 5C">View Details</a>
                 </div>
             </div>
             <div class="carousel-item">
@@ -268,7 +268,7 @@ ${topNavHtml?no_esc}
                      alt="Juwan Howard 1998-99 Fleer Metal Universe Precious Metal Gems 5"
                      title="Juwan Howard Private Collection - 1998-99 PMG">
                 <div class="hover-overlay">
-                    <a href="cards/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Fleer-Fleer-Metal-Universe-Base-Set-Precious-Metal-Gems-5-sn33-513.html" class="view-button" title="View details for Juwan Howard 1998-99 Fleer Metal Universe Precious Metal Gems 5">View Details</a>
+                    <a href="cards/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Fleer-Fleer-Metal-Universe-Base-Set-Precious-Metal-Gems-5-sn33-202e3390.html" class="view-button" title="View details for Juwan Howard 1998-99 Fleer Metal Universe Precious Metal Gems 5">View Details</a>
                 </div>
             </div>
             <div class="carousel-item">
@@ -277,7 +277,7 @@ ${topNavHtml?no_esc}
                      alt="Juwan Howard 1998-99 Fleer Brilliants Base 24 K Gold 97TG"
                      title="Juwan Howard Private Collection - 1998-99 Fleer Brilliants 24K Gold">
                 <div class="hover-overlay">
-                    <a href="cards/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Fleer-Fleer-Brilliants-Base-Set-24-K-Gold-97TG-sn14-507.html" class="view-button" title="View details for Juwan Howard 1998-99 Fleer Brilliants Base 24 K Gold 97TG">View Details</a>
+                    <a href="cards/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Fleer-Fleer-Brilliants-Base-Set-24-K-Gold-97TG-sn14-d253d68b.html" class="view-button" title="View details for Juwan Howard 1998-99 Fleer Brilliants Base 24 K Gold 97TG">View Details</a>
                 </div>
             </div>
             <div class="carousel-item">
@@ -286,7 +286,7 @@ ${topNavHtml?no_esc}
                      alt="Juwan Howard 2018-19 Panini Panini Contenders Optic Contenders Autographs Gold Vinyl LC JWH"
                      title="Juwan Howard Private Collection - 2018-19 Contenders Optic Gold Vinyl 1/1">
                 <div class="hover-overlay">
-                    <a href="cards/2018-19/Juwan-Howard-Washington-Wizards-2018-19-Panini-Panini-Contenders-Optic-Contenders-Autographs-Gold-Vinyl-LC-JWH-sn1-1266.html" class="view-button" title="View details for Juwan Howard 2018-19 Panini Panini Contenders Optic Contenders Autographs Gold Vinyl LC JWH">View Details</a>
+                    <a href="cards/2018-19/Juwan-Howard-Washington-Wizards-2018-19-Panini-Panini-Contenders-Optic-Contenders-Autographs-Gold-Vinyl-LC-JWH-sn1-e49f9113.html" class="view-button" title="View details for Juwan Howard 2018-19 Panini Panini Contenders Optic Contenders Autographs Gold Vinyl LC JWH">View Details</a>
                 </div>
             </div>
             <div class="carousel-item">
@@ -295,7 +295,7 @@ ${topNavHtml?no_esc}
                      alt="Juwan Howard 2018-19 Panini Panini Contenders Optic Contenders Autographs Gold Vinyl LC JWH"
                      title="Juwan Howard Private Collection - 2018-19 Contenders Optic Gold Vinyl 1/1">
                 <div class="hover-overlay">
-                    <a href="cards/2018-19/Juwan-Howard-Washington-Wizards-2018-19-Panini-Panini-Contenders-Optic-Contenders-Autographs-Gold-Vinyl-LC-JWH-sn1-1266.html" class="view-button" title="View details for Juwan Howard 2018-19 Panini Panini Contenders Optic Contenders Autographs Gold Vinyl LC JWH">View Details</a>
+                    <a href="cards/2018-19/Juwan-Howard-Washington-Wizards-2018-19-Panini-Panini-Contenders-Optic-Contenders-Autographs-Gold-Vinyl-LC-JWH-sn1-e49f9113.html" class="view-button" title="View details for Juwan Howard 2018-19 Panini Panini Contenders Optic Contenders Autographs Gold Vinyl LC JWH">View Details</a>
                 </div>
             </div>
             <div class="carousel-item">
@@ -304,7 +304,7 @@ ${topNavHtml?no_esc}
                      alt="Juwan Howard 1997-98 Fleer Metal Universe Precious Metal Gems Green"
                      title="Juwan Howard Private Collection - 1997-98 PMG Green 1/10">
                 <div class="hover-overlay">
-                    <a href="cards/1997-98/Juwan-Howard-Washington-Bullets-1997-98-Fleer-Fleer-Metal-Universe-Base-Set-Precious-Metal-Gems-Green-33-PMG-sn7-376.html" class="view-button" title="View details for Juwan Howard 1997-98 Fleer Metal Universe Precious Metal Gems Green">View Details</a>
+                    <a href="cards/1997-98/Juwan-Howard-Washington-Bullets-1997-98-Fleer-Fleer-Metal-Universe-Base-Set-Precious-Metal-Gems-Green-33-PMG-sn7-036109be.html" class="view-button" title="View details for Juwan Howard 1997-98 Fleer Metal Universe Precious Metal Gems Green">View Details</a>
                 </div>
             </div>
             <div class="carousel-item">
@@ -312,7 +312,7 @@ ${topNavHtml?no_esc}
                      loading="lazy" width="400" height="550" alt="Juwan Howard 1998-99 SPx Finite Base Spectrum"
                      title="Juwan Howard Private Collection - 1998-99 SPx Finite Spectrum">
                 <div class="hover-overlay">
-                    <a href="cards/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Upper-Deck-SPx-Finite-Base-Set-Spectrum-76-sn291-537.html" class="view-button" title="View details for Juwan Howard 1998-99 SPx Finite Base Spectrum">View Details</a>
+                    <a href="cards/1998-99/Juwan-Howard-Washington-Wizards-1998-99-Upper-Deck-SPx-Finite-Base-Set-Spectrum-76-sn291-0dd7be42.html" class="view-button" title="View details for Juwan Howard 1998-99 SPx Finite Base Spectrum">View Details</a>
                 </div>
             </div>
             <div class="carousel-item">
@@ -321,7 +321,7 @@ ${topNavHtml?no_esc}
                      alt="1997-98 Fleer Metal Universe Championship Precious Metal Gems 11"
                      title="Juwan Howard Private Collection - 1997-98 PMG Championship">
                 <div class="hover-overlay">
-                    <a href="cards/1997-98/Juwan-Howard-Washington-Wizards-1997-98-Fleer-Fleer-Metal-Universe-Championship-Base-Set-Precious-Metal-Gems-11-sn32-371.html" class="view-button" title="View details for 1997-98 Fleer Metal Universe Championship Precious Metal Gems 11">View Details</a>
+                    <a href="cards/1997-98/Juwan-Howard-Washington-Wizards-1997-98-Fleer-Fleer-Metal-Universe-Championship-Base-Set-Precious-Metal-Gems-11-sn32-bec55345.html" class="view-button" title="View details for 1997-98 Fleer Metal Universe Championship Precious Metal Gems 11">View Details</a>
                 </div>
             </div>
             <div class="carousel-item">
@@ -330,7 +330,7 @@ ${topNavHtml?no_esc}
                      alt="2022-23 Panini Panini Spectra Icons Autographs Nebula IA JUW"
                      title="Juwan Howard Private Collection - 2022-23 Spectra Nebula 1/1">
                 <div class="hover-overlay">
-                    <a href="cards/2022-23/Juwan-Howard-Washington-Wizards-2022-23-Panini-Panini-Spectra-Icons-Autographs-Nebula-IA-JUW-sn1-1348.html" class="view-button" title="View details for 2022-23 Panini Panini Spectra Icons Autographs Nebula IA JUW">View Details</a>
+                    <a href="cards/2022-23/Juwan-Howard-Washington-Wizards-2022-23-Panini-Panini-Spectra-Icons-Autographs-Nebula-IA-JUW-sn1-e5137523.html" class="view-button" title="View details for 2022-23 Panini Panini Spectra Icons Autographs Nebula IA JUW">View Details</a>
                 </div>
             </div>
             <div class="carousel-item">
@@ -339,7 +339,7 @@ ${topNavHtml?no_esc}
                      alt="2018-19 Panini Panini Flawless Legendary Scripts Platinum LS JWH"
                      title="Juwan Howard Private Collection - 2018-19 Flawless Platinum 1/1">
                 <div class="hover-overlay">
-                    <a href="cards/2018-19/Juwan-Howard-Miami-Heat-2018-19-Panini-Panini-Flawless-Legendary-Scripts-Platinum-LS-JWH-sn1-1245.html" class="view-button" title="View details for 2018-19 Panini Panini Flawless Legendary Scripts Platinum LS JWH">View Details</a>
+                    <a href="cards/2018-19/Juwan-Howard-Miami-Heat-2018-19-Panini-Panini-Flawless-Legendary-Scripts-Platinum-LS-JWH-sn1-0a9bf98e.html" class="view-button" title="View details for 2018-19 Panini Panini Flawless Legendary Scripts Platinum LS JWH">View Details</a>
                 </div>
             </div>
             <div class="carousel-item">
@@ -348,7 +348,7 @@ ${topNavHtml?no_esc}
                      alt="2016-17 Panini Panini Donruss Elite Signatures Black 99"
                      title="Juwan Howard Private Collection - 2016-17 Donruss Elite Black 1/1">
                 <div class="hover-overlay">
-                    <a href="cards/2016-17/Juwan-Howard-Miami-Heat-2016-17-Panini-Panini-Donruss-Elite-Signatures-Black-99-sn1-1205.html" class="view-button" title="View details for 2016-17 Panini Panini Donruss Elite Signatures Black 99">View Details</a>
+                    <a href="cards/2016-17/Juwan-Howard-Miami-Heat-2016-17-Panini-Panini-Donruss-Elite-Signatures-Black-99-sn1-ea4c7783.html" class="view-button" title="View details for 2016-17 Panini Panini Donruss Elite Signatures Black 99">View Details</a>
                 </div>
             </div>
             <div class="carousel-item">
@@ -357,7 +357,7 @@ ${topNavHtml?no_esc}
                      alt="2017-18 Panini Panini Donruss Optic Dominator Signatures Gold Vinyl 18"
                      title="Juwan Howard Private Collection - 2017-18 Optic Gold Vinyl 1/1">
                 <div class="hover-overlay">
-                    <a href="cards/2017-18/Juwan-Howard-Dallas-Mavericks-2017-18-Panini-Panini-Donruss-Optic-Dominator-Signatures-Gold-Vinyl-18-sn1-1236.html" class="view-button" title="View details for 2017-18 Panini Panini Donruss Optic Dominator Signatures Gold Vinyl 18">View Details</a>
+                    <a href="cards/2017-18/Juwan-Howard-Dallas-Mavericks-2017-18-Panini-Panini-Donruss-Optic-Dominator-Signatures-Gold-Vinyl-18-sn1-a2de02d4.html" class="view-button" title="View details for 2017-18 Panini Panini Donruss Optic Dominator Signatures Gold Vinyl 18">View Details</a>
                 </div>
             </div>
             <div class="carousel-item">
@@ -366,7 +366,7 @@ ${topNavHtml?no_esc}
                      alt="2017-18 Panini Panini Flawless Premium Ink Signatures Platinum PI JH"
                      title="Juwan Howard Private Collection - 2017-18 Flawless Premium Ink 1/1">
                 <div class="hover-overlay">
-                    <a href="cards/2017-18/Juwan-Howard-Miami-Heat-2017-18-Panini-Panini-Flawless-Premium-Ink-Signatures-Platinum-PI-JH-sn1-1240.html" class="view-button" title="View details for 2017-18 Panini Panini Flawless Premium Ink Signatures Platinum PI JH">View Details</a>
+                    <a href="cards/2017-18/Juwan-Howard-Miami-Heat-2017-18-Panini-Panini-Flawless-Premium-Ink-Signatures-Platinum-PI-JH-sn1-eaf6fed5.html" class="view-button" title="View details for 2017-18 Panini Panini Flawless Premium Ink Signatures Platinum PI JH">View Details</a>
                 </div>
             </div>
             <div class="carousel-item">
@@ -375,7 +375,7 @@ ${topNavHtml?no_esc}
                      alt="2013-14 Panini Panini Immaculate Collection Team Logos Numbers Jersey Patch 93"
                      title="Juwan Howard Private Collection - 2013-14 Immaculate Patch">
                 <div class="hover-overlay">
-                    <a href="cards/2013-14/Juwan-Howard-Washington-Wizards-2013-14-Panini-Panini-Immaculate-Collection-Team-Logos-Numbers-Jersey-Patch-93-sn7-1193.html" class="view-button" title="View details for 2013-14 Panini Panini Immaculate Collection Team Logos Numbers Jersey Patch 93">View Details</a>
+                    <a href="cards/2013-14/Juwan-Howard-Washington-Wizards-2013-14-Panini-Panini-Immaculate-Collection-Team-Logos-Numbers-Jersey-Patch-93-sn7-9a8732d2.html" class="view-button" title="View details for 2013-14 Panini Panini Immaculate Collection Team Logos Numbers Jersey Patch 93">View Details</a>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
Updated the hardcoded links in the `index.ftlh` template to match the current filename generation logic, which appends a stable 8-character hash instead of the previous numeric IDs. Verified the changes by running the site generation pipeline and performing visual verification with Playwright.

---
*PR created automatically by Jules for task [2381097824746743783](https://jules.google.com/task/2381097824746743783) started by @AndreasBild*