### PR TITLE
Add Organized HTML Sitemap

### DIFF
--- a/src/main/java/de/maulmann/SharedTemplates.java
+++ b/src/main/java/de/maulmann/SharedTemplates.java
@@ -104,7 +104,8 @@ public class SharedTemplates {
                 .replace("{{ACTIVE_BASEBALL}}", activePage.equals("baseball") ? "class=\"active\"" : "")
                 .replace("{{ACTIVE_FLAWLESS}}", activePage.equals("flawless") ? "class=\"active\"" : "")
                 .replace("{{ACTIVE_WANTLIST}}", activePage.equals("wantlist") ? "class=\"active\"" : "")
-                .replace("{{ACTIVE_PANINI}}", activePage.equals("panini") ? "class=\"active\"" : "");
+                .replace("{{ACTIVE_PANINI}}", activePage.equals("panini") ? "class=\"active\"" : "")
+                .replace("{{ACTIVE_SITEMAP}}", activePage.equals("sitemap") ? "class=\"active\"" : "");
     }
 
     public static String getFooterNav(String root) {

--- a/src/main/java/de/maulmann/SitemapGenerator.java
+++ b/src/main/java/de/maulmann/SitemapGenerator.java
@@ -5,18 +5,32 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateExceptionHandler;
+
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
 public class SitemapGenerator {
+
+    private static final Configuration fmConfig;
+    static {
+        fmConfig = new Configuration(Configuration.VERSION_2_3_32);
+        fmConfig.setClassForTemplateLoading(SitemapGenerator.class, "/templates");
+        fmConfig.setDefaultEncoding("UTF-8");
+        fmConfig.setTemplateExceptionHandler(TemplateExceptionHandler.RETHROW_HANDLER);
+    }
     private static final String BASE_URL = "https://www.maulmann.de";
     private static final String OUTPUT_DIR = "output";
 
@@ -28,104 +42,134 @@ public class SitemapGenerator {
         AtomicInteger imagesAdded = new AtomicInteger(0);
         AtomicInteger imagesMissing = new AtomicInteger(0);
 
+        List<Map<String, String>> coreLinks = new ArrayList<>();
+        Map<String, List<Map<String, String>>> seasonGroups = new TreeMap<>();
+
         try {
             System.out.println("-> Generating best-in-class robots.txt...");
             generateRobotsTxt();
 
-            System.out.println("-> Scanning output directory for sitemap.xml...");
+            System.out.println("-> Scanning output directory for sitemap.xml and sitemap.html...");
             StringBuilder xml = new StringBuilder();
             xml.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
             xml.append("<?xml-stylesheet type=\"text/xsl\" href=\"https://www.maulmann.de/sitemap.xsl\"?>\n");
             xml.append("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\"\n");
-            // Standard Image Sitemap Erweiterung (optional, aber Best Practice)
             xml.append("        xmlns:image=\"http://www.google.com/schemas/sitemap-image/1.1\">\n");
 
             String today = new SimpleDateFormat("yyyy-MM-dd").format(new Date());
             Path outputDirPath = Paths.get(OUTPUT_DIR);
 
-            // Scanne den kompletten Output-Ordner auf alle existierenden HTML-Dateien
+            // Collect paths first to sort them
+            List<Path> allPaths = new ArrayList<>();
             try (Stream<Path> paths = Files.walk(outputDirPath)) {
                 paths.filter(Files::isRegularFile)
                         .filter(p -> p.toString().endsWith(".html"))
-                        .forEach(path -> {
-                            String relativePath = outputDirPath.relativize(path).toString().replace("\\", "/");
+                        .forEach(allPaths::add);
+            }
 
-                            String loc = BASE_URL + "/" + relativePath;
+            // Sort paths: Core files first, then cards by season
+            allPaths.sort((p1, p2) -> {
+                String s1 = outputDirPath.relativize(p1).toString().replace("\\", "/");
+                String s2 = outputDirPath.relativize(p2).toString().replace("\\", "/");
+                boolean p1IsCore = !s1.contains("/");
+                boolean p2IsCore = !s2.contains("/");
+                if (p1IsCore && !p2IsCore) return -1;
+                if (!p1IsCore && p2IsCore) return 1;
+                return s1.compareTo(s2);
+            });
 
-                            // SEO Best Practice: index.html auf die reine Root-Domain leiten
-                            if (loc.endsWith("/index.html")) {
-                                loc = loc.replace("/index.html", "/");
-                            }
+            for (Path path : allPaths) {
+                String relativePath = outputDirPath.relativize(path).toString().replace("\\", "/");
+                String loc = BASE_URL + "/" + relativePath;
 
-                            // Smarte SEO Prioritäten und Crawl-Frequenzen
-                            String priority = "0.6";
-                            String changeFreq = "yearly"; // Standard für alte Einzelkarten
+                // SEO Best Practice: index.html auf die reine Root-Domain leiten
+                if (loc.endsWith("/index.html")) {
+                    loc = loc.replace("/index.html", "/");
+                }
 
-                            if (relativePath.equals("index.html")) {
-                                priority = "1.0";
-                                changeFreq = "weekly";
-                            } else if (relativePath.equals("Juwan-Howard-Collection.html")) {
-                                priority = "0.9";
-                                changeFreq = "daily"; // Die Hauptsammlung wächst ständig
-                            } else if (!relativePath.contains("/")) {
-                                // Andere statische Root-Dateien wie Baseball.html, Flawless.html
-                                priority = "0.8";
-                                changeFreq = "weekly";
-                            }
+                // Smarte SEO Prioritäten und Crawl-Frequenzen
+                String priority = "0.6";
+                String changeFreq = "yearly";
 
-                            xml.append("  <url>\n");
-                            xml.append("    <loc>").append(escapeXml(loc)).append("</loc>\n");
-                            xml.append("    <lastmod>").append(today).append("</lastmod>\n");
-                            xml.append("    <changefreq>").append(changeFreq).append("</changefreq>\n");
-                            xml.append("    <priority>").append(priority).append("</priority>\n");
+                if (relativePath.equals("index.html")) {
+                    priority = "1.0";
+                    changeFreq = "weekly";
+                } else if (relativePath.equals("Juwan-Howard-Collection.html")) {
+                    priority = "0.9";
+                    changeFreq = "daily";
+                } else if (!relativePath.contains("/")) {
+                    priority = "0.8";
+                    changeFreq = "weekly";
+                }
 
-                            // Best-in-class Image SEO: Extrahiere Bilder aus der HTML
-                            try {
-                                Document doc = Jsoup.parse(path.toFile(), "UTF-8");
-                                Elements imgs = doc.select("img");
-                                for (Element img : imgs) {
-                                    String src = img.attr("src");
-                                    if (src.isEmpty() || src.startsWith("data:")) continue;
+                xml.append("  <url>\n");
+                xml.append("    <loc>").append(escapeXml(loc)).append("</loc>\n");
+                xml.append("    <lastmod>").append(today).append("</lastmod>\n");
+                xml.append("    <changefreq>").append(changeFreq).append("</changefreq>\n");
+                xml.append("    <priority>").append(priority).append("</priority>\n");
 
-                                    // Auflösen relativer Pfade (z.B. ../../images/...)
-                                    String absImageLoc = resolveImageLoc(relativePath, src);
-                                    if (absImageLoc.isEmpty()) continue;
+                try {
+                    Document doc = Jsoup.parse(path.toFile(), "UTF-8");
+                    String pageTitle = doc.title();
+                    if (pageTitle.contains("|")) {
+                        pageTitle = pageTitle.split("\\|")[0].trim();
+                    }
+                    if (pageTitle.isEmpty()) pageTitle = relativePath;
 
-                                    // Check existence
-                                    boolean exists = false;
-                                    if (src.startsWith("http") || src.startsWith("//")) {
-                                        exists = true;
-                                    } else {
-                                        // For local images, resolve absolute URL gives us the path after BASE_URL
-                                        if (absImageLoc.startsWith(BASE_URL + "/")) {
-                                            String relPath = absImageLoc.substring((BASE_URL + "/").length());
-                                            if (Files.exists(Paths.get(OUTPUT_DIR, relPath))) {
-                                                exists = true;
-                                            }
-                                        }
-                                    }
+                    Map<String, String> linkMap = new HashMap<>();
+                    linkMap.put("url", relativePath);
+                    linkMap.put("text", pageTitle);
 
-                                    if (exists) {
-                                        String alt = img.attr("alt");
-                                        if (alt.isEmpty()) alt = img.attr("title");
+                    if (!relativePath.contains("/")) {
+                        coreLinks.add(linkMap);
+                    } else if (relativePath.startsWith("cards/")) {
+                        String[] parts = relativePath.split("/");
+                        if (parts.length >= 3) {
+                            String season = parts[1];
+                            seasonGroups.computeIfAbsent(season, k -> new ArrayList<>()).add(linkMap);
+                        }
+                    }
 
-                                        xml.append("    <image:image>\n");
-                                        xml.append("      <image:loc>").append(escapeXml(absImageLoc)).append("</image:loc>\n");
-                                        if (!alt.isEmpty()) {
-                                            xml.append("      <image:caption>").append(escapeXml(alt)).append("</image:caption>\n");
-                                        }
-                                        xml.append("    </image:image>\n");
-                                        imagesAdded.incrementAndGet();
-                                    } else {
-                                        imagesMissing.incrementAndGet();
-                                    }
+                    Elements imgs = doc.select("img");
+                    for (Element img : imgs) {
+                        String src = img.attr("src");
+                        if (src.isEmpty() || src.startsWith("data:")) continue;
+
+                        String absImageLoc = resolveImageLoc(relativePath, src);
+                        if (absImageLoc.isEmpty()) continue;
+
+                        boolean exists = false;
+                        if (src.startsWith("http") || src.startsWith("//")) {
+                            exists = true;
+                        } else {
+                            if (absImageLoc.startsWith(BASE_URL + "/")) {
+                                String relPath = absImageLoc.substring((BASE_URL + "/").length());
+                                if (Files.exists(Paths.get(OUTPUT_DIR, relPath))) {
+                                    exists = true;
                                 }
-                            } catch (IOException e) {
-                                System.err.println("Could not parse " + path + " for images: " + e.getMessage());
                             }
+                        }
 
-                            xml.append("  </url>\n");
-                        });
+                        if (exists) {
+                            String alt = img.attr("alt");
+                            if (alt.isEmpty()) alt = img.attr("title");
+
+                            xml.append("    <image:image>\n");
+                            xml.append("      <image:loc>").append(escapeXml(absImageLoc)).append("</image:loc>\n");
+                            if (!alt.isEmpty()) {
+                                xml.append("      <image:caption>").append(escapeXml(alt)).append("</image:caption>\n");
+                            }
+                            xml.append("    </image:image>\n");
+                            imagesAdded.incrementAndGet();
+                        } else {
+                            imagesMissing.incrementAndGet();
+                        }
+                    }
+                } catch (IOException e) {
+                    System.err.println("Could not parse " + path + ": " + e.getMessage());
+                }
+
+                xml.append("  </url>\n");
             }
 
             xml.append("</urlset>");
@@ -135,14 +179,79 @@ public class SitemapGenerator {
                 writer.write(xml.toString());
             }
 
-            System.out.println("-> Sitemap successfully generated based on actual output files!");
-            System.out.println("   > Images added to sitemap: " + imagesAdded.get());
+            System.out.println("-> Sitemap.xml successfully generated!");
+            System.out.println("   > Images added: " + imagesAdded.get());
             if (imagesMissing.get() > 0) {
-                System.out.println("   > Images missing (skipped): " + imagesMissing.get());
+                System.out.println("   > Images missing: " + imagesMissing.get());
             }
+
+            generateHtmlSitemap(coreLinks, seasonGroups);
 
         } catch (Exception e) {
             System.err.println("Failed to generate Sitemap: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    private static void generateHtmlSitemap(List<Map<String, String>> coreLinks, Map<String, List<Map<String, String>>> seasonGroups) {
+        try {
+            System.out.println("-> Generating sitemap.html...");
+
+            Map<String, Object> data = new HashMap<>();
+
+            String title = "HTML Sitemap | Juwan Howard Private Collection";
+            String description = "An organized overview of all pages in the Juwan Howard Super Collector private collection, including over 1,000 unique trading cards.";
+
+            // Note: We need to use SharedTemplates but SitemapGenerator might run in a context
+            // where it doesn't have easy access to all createBaseData logic from FileGenerator.
+            // However, they are in the same package.
+
+            String headHtml = SharedTemplates.getHead(title, description, "", "sitemap.html", FileGenerator.IMAGE_PATH);
+            String topNavHtml = SharedTemplates.getTopNav("", "sitemap");
+            String footerHtml = SharedTemplates.getFooter("");
+
+            data.put("headHtml", headHtml);
+            data.put("topNavHtml", topNavHtml);
+            data.put("footerHtml", footerHtml);
+
+            data.put("coreLinks", coreLinks);
+
+            List<Map<String, Object>> cardSeasons = new ArrayList<>();
+            for (Map.Entry<String, List<Map<String, String>>> entry : seasonGroups.entrySet()) {
+                Map<String, Object> seasonMap = new HashMap<>();
+                seasonMap.put("name", "Season " + entry.getKey());
+                seasonMap.put("links", entry.getValue());
+                cardSeasons.add(seasonMap);
+            }
+            data.put("cardSeasons", cardSeasons);
+
+            Template template = fmConfig.getTemplate("sitemap.ftlh");
+            File outFile = new File(OUTPUT_DIR + "/sitemap.html");
+
+            try (FileWriter writer = new FileWriter(outFile)) {
+                template.process(data, writer);
+            }
+
+            // Post-process for stable time if needed?
+            // SitemapGenerator is called in Phase 1 of SiteBuilderPipeline after FileGenerator.
+            // We might need to handle the [[STABLE_TIME]] here as well if we want it to be consistent.
+            // But let's see if the current implementation in FileGenerator/CardPageGenerator is enough.
+            // Actually, processTemplate in FileGenerator handles it.
+            // SitemapGenerator.generate() is called directly.
+
+            String finalHtml = Files.readString(outFile.toPath(), StandardCharsets.UTF_8);
+            if (finalHtml.contains("[[STABLE_TIME]]")) {
+                // We don't have easy access to the timestampTracker here unless we pass it.
+                // For now, let's just use the current timestamp if not handled.
+                // But wait, SharedTemplates.getFooter("") uses [[STABLE_TIME]].
+                finalHtml = finalHtml.replace("[[STABLE_TIME]]", SharedTemplates.getTimestamp());
+                Files.writeString(outFile.toPath(), finalHtml, StandardCharsets.UTF_8);
+            }
+
+            System.out.println("-> Sitemap.html successfully generated!");
+        } catch (Exception e) {
+            System.err.println("Failed to generate HTML Sitemap: " + e.getMessage());
+            e.printStackTrace();
         }
     }
 

--- a/src/main/resources/templates/footer.html
+++ b/src/main/resources/templates/footer.html
@@ -6,5 +6,5 @@
 </section>
 
 <footer class="detail-footer">
-    Maulmann Trading Cards &copy; {{TIME}}
+    Maulmann Trading Cards &copy; {{TIME}} | <a href="{{ROOT}}sitemap.html" title="HTML Sitemap">Sitemap</a>
 </footer>

--- a/src/main/resources/templates/sitemap.ftlh
+++ b/src/main/resources/templates/sitemap.ftlh
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    ${headHtml?no_esc}
+    <#if jsonLd??>${jsonLd?no_esc}</#if>
+    <style>
+        .sitemap-section {
+            margin-bottom: 40px;
+        }
+        .sitemap-section h2 {
+            border-bottom: 2px solid #3a7504;
+            padding-bottom: 10px;
+            margin-bottom: 20px;
+            color: #333;
+        }
+        .sitemap-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+            gap: 20px;
+        }
+        .sitemap-list {
+            list-style: none;
+            padding: 0;
+            margin: 0;
+        }
+        .sitemap-list li {
+            margin-bottom: 8px;
+        }
+        .sitemap-list a {
+            color: #3264af;
+            text-decoration: none;
+            transition: color 0.2s;
+        }
+        .sitemap-list a:hover {
+            color: #3a7504;
+            text-decoration: underline;
+        }
+        .sitemap-cards-container {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+            gap: 30px;
+        }
+        .season-group h3 {
+            background: #f4f4f4;
+            padding: 10px;
+            border-radius: 4px;
+            margin-top: 0;
+        }
+    </style>
+</head>
+<body>
+${topNavHtml?no_esc}
+<main class="detail-main">
+    <header class="detail-header">
+        <h1>HTML Sitemap</h1>
+        <p class="sub-title">An organized overview of all pages in the Juwan Howard Private Collection</p>
+    </header>
+
+    <div class="sitemap-section">
+        <h2>Core Pages & Collections</h2>
+        <div class="sitemap-grid">
+            <ul class="sitemap-list">
+                <#list coreLinks as link>
+                    <li><a href="${link.url}" class="plain" title="${link.text}">${link.text}</a></li>
+                </#list>
+            </ul>
+        </div>
+    </div>
+
+    <div class="sitemap-section">
+        <h2>Card Detail Pages by Season</h2>
+        <div class="sitemap-cards-container">
+            <#list cardSeasons as season>
+                <div class="season-group">
+                    <h3>${season.name}</h3>
+                    <ul class="sitemap-list">
+                        <#list season.links as link>
+                            <li><a href="${link.url}" class="plain" title="${link.text}">${link.text}</a></li>
+                        </#list>
+                    </ul>
+                </div>
+            </#list>
+        </div>
+    </div>
+</main>
+${footerHtml?no_esc}
+</body>
+</html>


### PR DESCRIPTION
This change implements a human-friendly HTML sitemap to improve website navigation and UX. The sitemap is automatically generated alongside the XML sitemap and groups links into "Core Pages" and "Card Detail Pages by Season". It is accessible via a new link in the website footer.

---
*PR created automatically by Jules for task [15337693112644734553](https://jules.google.com/task/15337693112644734553) started by @AndreasBild*