### PR TITLE
Fix JSON-LD structured data parsing error and update error page

### DIFF
--- a/src/main/java/de/maulmann/CardPageGenerator.java
+++ b/src/main/java/de/maulmann/CardPageGenerator.java
@@ -633,7 +633,7 @@ public class CardPageGenerator {
         sb.append("      \"about\": {\n");
         sb.append("        \"@type\": \"Person\",\n");
         sb.append("        \"name\": \"").append(escapeJson(c.get("Player"))).append("\",\n");
-        sb.append("        \"sameAs\": \"https://en.wikipedia.org/wiki/").append(escapeJson(c.get("Player"))).append("\n");
+        sb.append("        \"sameAs\": \"https://en.wikipedia.org/wiki/").append(escapeJson(c.get("Player")).replace(" ", "_")).append("\"\n");
         sb.append("      },\n");
         sb.append("      \"artMedium\": \"Trading Card\",\n");
         sb.append("      \"artform\": \"Sports Memorabilia\"\n");

--- a/src/main/resources/templates/error.ftlh
+++ b/src/main/resources/templates/error.ftlh
@@ -6,7 +6,7 @@
 <body>
 ${topNavHtml?no_esc}
 <main class="detail-main" style="text-align: center; padding: 100px 20px; min-height: 50vh;">
-    <h1 style="font-size: 5em; color: #3264af; margin: 0;">Error Page</h1>
+    <h1 style="font-size: 5em; color: #3264af; margin: 0;">404</h1>
     <h2 style="font-size: 2em; color: #333;">Requested Card Not Found</h2>
     <p style="color: #666; margin-bottom: 40px; font-size: 1.2em;">The card or collection you are looking for has been
         traded, lost in the mail, or doesn't exist.</p>


### PR DESCRIPTION
This PR fixes a critical structured data parsing error reported in Google Search Console. The error was caused by a missing closing quote in the `sameAs` property of the `VisualArtwork` schema in `CardPageGenerator.java`. Additionally, the player name in the Wikipedia URL is now correctly formatted with underscores. 

The `error.ftlh` template was also updated to include '404' in the heading, which resolves a pre-existing test failure in `FileGeneratorTest`.

---
*PR created automatically by Jules for task [1642813523355441294](https://jules.google.com/task/1642813523355441294) started by @AndreasBild*