### PR TITLE
Fix incorrect @type in FAQ structured data

### DIFF
--- a/content/other/Panini.html
+++ b/content/other/Panini.html
@@ -211,10 +211,8 @@
                     "@type": "Question",
                     "name": "Why is the 2012-13 season significant for Panini Flawless?",
                     "acceptedAnswer": {
-                        "@type": {
-                            "type": "Answer",
-                            "text": "2012-13 was the debut year of Flawless, a milestone that redefined luxury basketball card sets by focusing on premium materials, low serial numbers, and 100% on-card autographs."
-                        }
+                        "@type": "Answer",
+                        "text": "2012-13 was the debut year of Flawless, a milestone that redefined luxury basketball card sets by focusing on premium materials, low serial numbers, and 100% on-card autographs."
                     }
                 },
                 {


### PR DESCRIPTION
This PR fixes a structured data issue where the `@type` property in the FAQ JSON-LD section of the Panini page was incorrectly defined as an object instead of a string (`"Answer"`). This caused a "Falscher Werttyp '@type'" error in Google Search Console. 

Changes:
- Corrected the malformed JSON-LD in `content/other/Panini.html`.
- Verified that `content/other/Baseball.html` and `content/other/Flawless.html` do not have this issue.
- Re-generated the static site to apply the fix to the output.
- Verified the fix in the generated `output/Panini.html`.
- Confirmed that no other similar errors exist in the `content/other/` directory.

---
*PR created automatically by Jules for task [6149137566934147013](https://jules.google.com/task/6149137566934147013) started by @AndreasBild*