### PR TITLE
Add name attribute to top-level Structured Data elements

### DIFF
--- a/content/other/Baseball.html
+++ b/content/other/Baseball.html
@@ -136,6 +136,7 @@
         {
             "@context": "https://schema.org",
             "@type": "FAQPage",
+            "name": "Frequently Asked Questions",
             "mainEntity": [
                 {
                     "@type": "Question",

--- a/content/other/Flawless.html
+++ b/content/other/Flawless.html
@@ -418,6 +418,7 @@
         {
             "@context": "https://schema.org",
             "@type": "FAQPage",
+            "name": "Frequently Asked Questions",
             "mainEntity": [
                 {
                     "@type": "Question",

--- a/content/other/Panini.html
+++ b/content/other/Panini.html
@@ -190,6 +190,7 @@
         {
             "@context": "https://schema.org",
             "@type": "FAQPage",
+            "name": "Frequently Asked Questions",
             "mainEntity": [
                 {
                     "@type": "Question",

--- a/content/other/Wantlist.html
+++ b/content/other/Wantlist.html
@@ -212,6 +212,7 @@
         {
             "@context": "https://schema.org",
             "@type": "FAQPage",
+            "name": "Frequently Asked Questions",
             "mainEntity": [
                 {
                     "@type": "Question",

--- a/src/main/java/de/maulmann/CardPageGenerator.java
+++ b/src/main/java/de/maulmann/CardPageGenerator.java
@@ -613,6 +613,7 @@ public class CardPageGenerator {
         // 1. BreadcrumbList
         sb.append("    {\n");
         sb.append("      \"@type\": \"BreadcrumbList\",\n");
+        sb.append("      \"name\": \"Breadcrumbs\",\n");
         sb.append("      \"itemListElement\": [\n");
         sb.append("        { \"@type\": \"ListItem\", \"position\": 1, \"name\": \"Home\", \"item\": \"").append(BASE_URL).append("/index.html\" },\n");
         sb.append("        { \"@type\": \"ListItem\", \"position\": 2, \"name\": \"Collection\", \"item\": \"").append(BASE_URL).append("/").append(overviewPage).append("\" },\n");
@@ -674,6 +675,7 @@ public class CardPageGenerator {
             sb.append(",\n");
             sb.append("    {\n");
             sb.append("      \"@type\": \"FAQPage\",\n");
+            sb.append("      \"name\": \"Frequently Asked Questions\",\n");
             sb.append("      \"mainEntity\": [\n");
 
             Document doc = Jsoup.parseBodyFragment(faqHtml);

--- a/src/main/java/de/maulmann/FileGenerator.java
+++ b/src/main/java/de/maulmann/FileGenerator.java
@@ -52,6 +52,7 @@ public class FileGenerator {
                     "  \"@graph\": [\n" +
                     "    {\n" +
                     "      \"@type\": \"BreadcrumbList\",\n" +
+                    "      \"name\": \"Breadcrumbs\",\n" +
                     "      \"itemListElement\": [\n" +
                     "        { \"@type\": \"ListItem\", \"position\": 1, \"name\": \"Home\", \"item\": \"" + BASE_URL + "/index.html\" },\n" +
                     "        { \"@type\": \"ListItem\", \"position\": 2, \"name\": \"Collection\", \"item\": \"" + BASE_URL + "/Juwan-Howard-Collection.html\" }\n" +
@@ -163,6 +164,7 @@ public class FileGenerator {
                         "  \"@graph\": [\n" +
                         "    {\n" +
                         "      \"@type\": \"BreadcrumbList\",\n" +
+                        "      \"name\": \"Breadcrumbs\",\n" +
                         "      \"itemListElement\": [\n" +
                         "        { \"@type\": \"ListItem\", \"position\": 1, \"name\": \"Home\", \"item\": \"" + BASE_URL + "/index.html\" },\n" +
                         "        { \"@type\": \"ListItem\", \"position\": 2, \"name\": \"" + coll + "\", \"item\": \"" + BASE_URL + "/" + coll + ".html\" }\n" +
@@ -197,6 +199,7 @@ public class FileGenerator {
                                         "  \"@graph\": [\n" +
                                         "    {\n" +
                                         "      \"@type\": \"BreadcrumbList\",\n" +
+                                        "      \"name\": \"Breadcrumbs\",\n" +
                                         "      \"itemListElement\": [\n" +
                                         "        { \"@type\": \"ListItem\", \"position\": 1, \"name\": \"Home\", \"item\": \"" + BASE_URL + "/index.html\" },\n" +
                                         "        { \"@type\": \"ListItem\", \"position\": 2, \"name\": \"" + coll + "\", \"item\": \"" + BASE_URL + "/" + coll + ".html\" }\n" +


### PR DESCRIPTION
This change adds a `name` attribute to top-level Schema.org elements in the JSON-LD graphs. Specifically, `BreadcrumbList` elements are now named "Breadcrumbs" and `FAQPage` elements are named "Frequently Asked Questions". This follows the Schema.org definition where these types inherit from `Thing`.

---
*PR created automatically by Jules for task [12433782617400393864](https://jules.google.com/task/12433782617400393864) started by @AndreasBild*