### PR TITLE
Standardize button widths in table overviews

### DIFF
--- a/src/main/java/de/maulmann/CardPageGenerator.java
+++ b/src/main/java/de/maulmann/CardPageGenerator.java
@@ -331,6 +331,7 @@ public class CardPageGenerator {
                             playerCell.empty();
                             playerCell.appendElement("a")
                                     .attr("href", matchingCard.fullRelativePath)
+                                    .attr("class", "table-button")
                                     .attr("title", "View details for " + matchingCard.get("Season") + " " + matchingCard.get("Brand") + " #" + matchingCard.get("Number"))
                                     .text(originalText);
                         }

--- a/src/main/resources/css/main.css
+++ b/src/main/resources/css/main.css
@@ -45,6 +45,20 @@ a:not(.plain) {
     transform: translateY(-1px);
 }
 
+/* --- TABLE BUTTONS (Consistent width in overviews) --- */
+.table-button {
+    width: 180px; /* Fixed width for consistency */
+    padding: 8px 12px !important;
+    margin: 2px !important;
+    font-size: 0.85rem !important;
+    display: inline-flex !important;
+    justify-content: center;
+    text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 /* --- TOP NAVIGATION (Sticky) --- */
 .topnav {
     overflow: hidden;
@@ -184,6 +198,13 @@ tr:hover {
         font-size: 0.8rem !important;
         min-width: 0 !important;
         margin: 2px !important;
+    }
+
+    .table-button {
+        width: 120px !important; /* Consistent width even on mobile */
+        padding: 6px 4px !important;
+        font-size: 0.75rem !important;
+        margin: 1px !important;
     }
 
     .detail-header h1 {


### PR DESCRIPTION
Standardized the visual presentation of the Flawless, Wantlist, Baseball, and Panini overview tables by ensuring all buttons have a consistent width. This was achieved by adding a new `.table-button` CSS class with a fixed width and applying it to the player links generated in `CardPageGenerator.java`. The solution also handles mobile responsiveness and long player names using text truncation with ellipsis.

---
*PR created automatically by Jules for task [12347300562676749463](https://jules.google.com/task/12347300562676749463) started by @AndreasBild*