### PR TITLE
Fix table overflow in collection pages

### DIFF
--- a/src/main/resources/css/main.css
+++ b/src/main/resources/css/main.css
@@ -117,6 +117,13 @@ a:not(.plain) {
 }
 
 /* --- TABELLEN STYLING --- */
+.table-responsive {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    width: 100%;
+    margin: 20px 0;
+}
+
 table {
     width: 100%;
     border-collapse: collapse;

--- a/src/main/resources/templates/collection-overview.ftlh
+++ b/src/main/resources/templates/collection-overview.ftlh
@@ -48,7 +48,7 @@ ${topNavHtml?no_esc}
                 Cards this season: <span class="visible-counter">${season.seasonCount}</span>
                 / ${season.cumulativeTotal}
             </p>
-            <div style="background: #fff; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.05); overflow: hidden; overflow-x: auto;">
+            <div class="table-responsive" style="background: #fff; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.05);">
                 ${season.content?no_esc}
             </div>
         </div>

--- a/src/main/resources/templates/generic-collection.ftlh
+++ b/src/main/resources/templates/generic-collection.ftlh
@@ -7,7 +7,7 @@
 <body>
 ${topNavHtml?no_esc}
 <main class="detail-main">
-    <div class="collection-table-wrapper"
+    <div class="collection-table-wrapper table-responsive"
          style="background: #fff; padding: 20px; border-radius: 8px; box-shadow: 0 2px 10px rgba(0,0,0,0.05);">
         ${pageContent?no_esc}
     </div>


### PR DESCRIPTION
Added a new `.table-responsive` CSS class and updated the collection templates to ensure that tables do not overflow their containers, especially on mobile devices or when they contain many columns. This specifically fixes the layout issues reported on `Baseball.html`.

---
*PR created automatically by Jules for task [17722240358932889181](https://jules.google.com/task/17722240358932889181) started by @AndreasBild*