### PR TITLE
Fix llms.txt deployment and improve CSS cache busting

### DIFF
--- a/src/main/java/de/maulmann/FileGenerator.java
+++ b/src/main/java/de/maulmann/FileGenerator.java
@@ -234,11 +234,34 @@ public class FileGenerator {
 
     public static void copyResources() {
         try {
+            // 1. Copy CSS
             Path cssDir = Paths.get(pathOutput, "css");
             Files.createDirectories(cssDir);
             Path cssSource = Paths.get("src/main/resources/css/main.css");
             if (Files.exists(cssSource)) {
                 Files.copy(cssSource, cssDir.resolve("main.css"), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+            }
+
+            // 2. Copy llms.txt from root
+            Path llmsSource = Paths.get("llms.txt");
+            if (Files.exists(llmsSource)) {
+                Files.copy(llmsSource, Paths.get(pathOutput, "llms.txt"), java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+            }
+
+            // 3. Copy PWA assets
+            Path pwaSourceDir = Paths.get("src/main/resources/pwa");
+            if (Files.exists(pwaSourceDir)) {
+                try (var stream = Files.walk(pwaSourceDir)) {
+                    stream.filter(Files::isRegularFile).forEach(source -> {
+                        try {
+                            Path target = Paths.get(pathOutput).resolve(pwaSourceDir.relativize(source));
+                            Files.createDirectories(target.getParent());
+                            Files.copy(source, target, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+                        } catch (IOException e) {
+                            System.err.println("Error copying PWA asset " + source + ": " + e.getMessage());
+                        }
+                    });
+                }
             }
         } catch (IOException e) {
             System.err.println("Error copying resources: " + e.getMessage());

--- a/src/main/java/de/maulmann/SiteBuilderPipeline.java
+++ b/src/main/java/de/maulmann/SiteBuilderPipeline.java
@@ -61,7 +61,12 @@ public class SiteBuilderPipeline {
             TimestampTracker timeTracker = new TimestampTracker(OUTPUT_DIR + "/generation-timestamps.properties");
 
             // Ensure stable CSS version for hash stability if content didn't change
-            SharedTemplates.setBuildId("stable");
+            String cssHash = tracker.getHash(Paths.get("src/main/resources/css/main.css"));
+            if (cssHash != null && cssHash.length() >= 8) {
+                SharedTemplates.setBuildId(cssHash.substring(0, 8));
+            } else {
+                SharedTemplates.setBuildId("stable");
+            }
 
             // --- PHASE 1: Generate Site HTML & Sitemap ---
             System.out.println("\n[PHASE 1] Generating HTML files and Sitemap...");
@@ -157,7 +162,7 @@ public class SiteBuilderPipeline {
                         uploadTask = uploadBytesAsync(s3Client, s3Key, gzippedData, "application/xml", "gzip", CACHE_SHORT, uploadCount);
                     } else if (fileName.endsWith(".ico")) {
                         uploadTask = uploadRawFileAsync(s3Client, file, s3Key, "image/x-icon", CACHE_LONG, uploadCount);
-                    } else if (fileName.startsWith("robots")) {
+                    } else if (fileName.startsWith("robots") || fileName.endsWith(".txt")) {
                         byte[] brData = BrotliCompressor.compressBytes(Files.readAllBytes(file), BrotliCompressor.BEST_QUALITY);
                         uploadTask = uploadBytesAsync(s3Client, s3Key, brData, "text/plain", "br", CACHE_SHORT, uploadCount);
                     }


### PR DESCRIPTION
This PR addresses two main issues:
1. `llms.txt` not being updated on AWS: The build process was modified to ensure `llms.txt` is copied from the root to the output directory, and the deployment pipeline was updated to correctly handle and upload `.txt` files to S3 with appropriate headers and compression.
2. Aggressive CSS caching: Instead of using a static or timestamp-based build ID, we now calculate an MD5 hash of the `main.css` file. This hash is used as a version query parameter in the HTML templates, ensuring that browsers only fetch a new version when the CSS content actually changes.
Additionally, PWA assets are now correctly copied to the output root, which helps with overall site reliability and caching management.

---
*PR created automatically by Jules for task [5348777717088602311](https://jules.google.com/task/5348777717088602311) started by @AndreasBild*