### PR TITLE
Fix layout and table overflow issues

### DIFF
--- a/src/main/java/de/maulmann/FileGenerator.java
+++ b/src/main/java/de/maulmann/FileGenerator.java
@@ -184,11 +184,11 @@ public class FileGenerator {
                 Path sourcePath = Paths.get(pathSource, "other", coll + ".html");
                 if (Files.exists(sourcePath)) {
                     String rawContent = Files.readString(sourcePath, StandardCharsets.UTF_8);
+                    Document doc = Jsoup.parse(rawContent);
 
                     // Extrahiere FAQ aus dem Content für das JSON-LD (falls vorhanden)
                     if (rawContent.contains("application/ld+json") && rawContent.contains("FAQPage")) {
                         try {
-                            Document doc = Jsoup.parse(rawContent);
                             Element faqScript = doc.selectFirst("script[type=application/ld+json]");
                             if (faqScript != null) {
                                 String faqJson = faqScript.data().trim();
@@ -222,7 +222,22 @@ public class FileGenerator {
                         }
                     }
 
-                    data.put("pageContent", cleanOldPlaceholders(rawContent));
+                    // NEU: Isoliere den Inhalt des <main>-Tags, um doppelte Verschachtelung zu vermeiden
+                    Element mainElement = doc.selectFirst("main");
+                    String processedContent;
+                    if (mainElement != null) {
+                        // Alle Tabellen automatisch in responsive Container einpacken, falls noch nicht geschehen
+                        for (Element table : mainElement.select("table")) {
+                            if (table.parent() == null || !table.parent().hasClass("table-responsive")) {
+                                table.wrap("<div class=\"table-responsive card-container-box\"></div>");
+                            }
+                        }
+                        processedContent = mainElement.html();
+                    } else {
+                        processedContent = rawContent;
+                    }
+
+                    data.put("pageContent", cleanOldPlaceholders(processedContent));
                 } else {
                     data.put("pageContent", "<p>No data found for this collection yet.</p>");
                 }

--- a/src/main/resources/css/main.css
+++ b/src/main/resources/css/main.css
@@ -1,4 +1,8 @@
 /* --- BASIS RESETS & FONTS --- */
+* {
+    box-sizing: border-box;
+}
+
 body {
     font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;
     line-height: 1.5;
@@ -6,6 +10,7 @@ body {
     color: #222;
     background-color: #fff;
     -webkit-text-size-adjust: 100%;
+    overflow-x: hidden;
 }
 
 body, td, th {
@@ -152,6 +157,8 @@ a:not(.plain) {
     max-width: 1200px;
     margin: 0 auto;
     padding: 20px;
+    width: 100%;
+    overflow-wrap: break-word;
 }
 
 .detail-header {
@@ -185,6 +192,11 @@ a:not(.plain) {
 .archive-text {
     margin: 0;
     color: #555;
+}
+
+.seo-box {
+    margin-bottom: 30px;
+    width: 100%;
 }
 
 .seo-box-centered {

--- a/src/main/resources/templates/generic-collection.ftlh
+++ b/src/main/resources/templates/generic-collection.ftlh
@@ -7,7 +7,7 @@
 <body>
 ${topNavHtml?no_esc}
 <main class="detail-main">
-    <div class="card-images-container card-container-box">
+    <div class="generic-content">
         ${pageContent?no_esc}
     </div>
 </main>


### PR DESCRIPTION
I have addressed the overflow issues on the website. 

Key changes include:
1. **Global CSS Improvements**: Applied `box-sizing: border-box` to all elements to ensure padding doesn't cause overflow. Added `overflow-wrap: break-word` to the main content container to prevent long strings from breaking the layout.
2. **Backend Logic Updates**: Modified `FileGenerator.java` to extract only the inner HTML of the `<main>` tag from source files, preventing the "double-nesting" of main containers that caused layout issues on secondary pages like Baseball and Flawless.
3. **Automated Responsive Tables**: Updated the generator to automatically wrap any `<table>` found in the content with a responsive wrapper (`table-responsive`), ensuring horizontal scrolling on smaller screens.
4. **Template Cleanup**: Standardized the content wrapper in `generic-collection.ftlh`.
5. **Full Site Regeneration**: Recompiled the project and regenerated all HTML files to ensure the fixes are applied consistently across the entire site.

---
*PR created automatically by Jules for task [15295224158970402523](https://jules.google.com/task/15295224158970402523) started by @AndreasBild*