### PR TITLE
Add BreadcrumbList JSON-LD to index page

### DIFF
--- a/src/main/java/de/maulmann/FileGenerator.java
+++ b/src/main/java/de/maulmann/FileGenerator.java
@@ -294,11 +294,18 @@ public class FileGenerator {
                     "Welcome to the ultimate Juwan Howard Private Collection. A Super Collector showcase featuring 1,000+ unique cards, including 1/1 Masterpieces, PMGs, Rubies, and rare 90s basketball inserts.",
                     "index.html", "index", "");
 
-            // Complex JSON-LD for Index (WebSite, Person, Collection)
+            // Complex JSON-LD for Index (WebSite, Person, Collection, Breadcrumbs)
             String indexJsonLd = "<script type=\"application/ld+json\">\n" +
                     "{\n" +
                     "  \"@context\": \"https://schema.org\",\n" +
                     "  \"@graph\": [\n" +
+                    "    {\n" +
+                    "      \"@type\": \"BreadcrumbList\",\n" +
+                    "      \"name\": \"Breadcrumbs\",\n" +
+                    "      \"itemListElement\": [\n" +
+                    "        { \"@type\": \"ListItem\", \"position\": 1, \"name\": \"Home\", \"item\": \"" + BASE_URL + "/index.html\" }\n" +
+                    "      ]\n" +
+                    "    },\n" +
                     "    {\n" +
                     "      \"@type\": \"WebSite\",\n" +
                     "      \"name\": \"Maulmann Trading Cards\",\n" +


### PR DESCRIPTION
This change adds BreadcrumbList structured data to the index page's JSON-LD @graph. While the index page is the root, including a 'Home' breadcrumb maintain consistency with other collection and card detail pages that already feature breadcrumbs. The implementation follows the Schema.org standard and includes the mandatory 'name' attribute required by the project's accessibility and SEO directives.

---
*PR created automatically by Jules for task [15296606206491663380](https://jules.google.com/task/15296606206491663380) started by @AndreasBild*