### PR TITLE
Unify Netty versions to resolve NoClassDefFoundError

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <maven.compiler.target>19</maven.compiler.target>
         <maven.compiler.release>19</maven.compiler.release>
         <aws.sdk.version>2.45.0</aws.sdk.version>
+        <netty.version>4.1.133.Final</netty.version>
         <org.slf4j.version>2.0.18</org.slf4j.version>
         <org.junit.jupiter.version>6.1.0</org.junit.jupiter.version>
         <org.apache.maven.plugins.version>3.15.0</org.apache.maven.plugins.version>
@@ -21,6 +22,18 @@
         <com.yahoo.platform.yui.version>2.4.8</com.yahoo.platform.yui.version>
         <com.google.firebase.version>9.9.0</com.google.firebase.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
This PR addresses a critical runtime crash (NoClassDefFoundError: io/netty/util/concurrent/ThreadAwareExecutor) and deprecation warnings by unifying Netty dependencies.

The issue was caused by a version mismatch: the AWS SDK was pulling in Netty 4.1.x, while Firebase Admin was pulling in Netty 4.2.x. These versions are not fully binary compatible in their internal utility classes.

Changes:
- Added `netty.version` property to `pom.xml`.
- Added `dependencyManagement` section with `netty-bom` set to version `4.1.133.Final`.
- Verified with `mvn dependency:tree` that all Netty components are now aligned.
- Confirmed that `SiteBuilderPipeline` can now initialize the AWS S3 client without crashing.

---
*PR created automatically by Jules for task [4999242628043776650](https://jules.google.com/task/4999242628043776650) started by @AndreasBild*