### PR TITLE
Integrate FirestoreRatingInjector into SiteBuilderPipeline

### DIFF
--- a/src/main/java/de/maulmann/FirestoreRatingInjector.java
+++ b/src/main/java/de/maulmann/FirestoreRatingInjector.java
@@ -101,17 +101,24 @@ public class FirestoreRatingInjector {
             return;
         }
 
+        java.util.concurrent.atomic.AtomicInteger count = new java.util.concurrent.atomic.AtomicInteger(0);
         try (Stream<Path> paths = Files.walk(targetPath)) {
             paths.filter(Files::isRegularFile)
                  .filter(p -> p.toString().endsWith(".html"))
-                 .forEach(path -> injectRating(path, firestoreData));
+                 .forEach(path -> {
+                     if (injectRating(path, firestoreData)) {
+                         count.incrementAndGet();
+                     }
+                 });
         }
+        log.info("Completed: Injected ratings into {} files.", count.get());
     }
 
     /**
      * Parses a single HTML file, extracts the card ID, and injects the AggregateRating JSON-LD if data exists.
+     * @return true if rating was injected, false otherwise.
      */
-    private static void injectRating(Path path, Map<String, Map<String, Object>> firestoreData) {
+    private static boolean injectRating(Path path, Map<String, Map<String, Object>> firestoreData) {
         try {
             File file = path.toFile();
             Document doc = Jsoup.parse(file, "UTF-8");
@@ -119,7 +126,7 @@ public class FirestoreRatingInjector {
             // Extract card ID from data-card-id attribute (e.g. on vote-container)
             Element cardElement = doc.select("[data-card-id]").first();
             if (cardElement == null) {
-                return; // Not a card detail page or missing ID
+                return false; // Not a card detail page or missing ID
             }
 
             String cardId = cardElement.attr("data-card-id");
@@ -143,12 +150,14 @@ public class FirestoreRatingInjector {
                     // Overwrite the original file with modified DOM
                     Files.writeString(path, doc.outerHtml(), StandardCharsets.UTF_8);
                     log.info("Injected ratings into: {}", path.getFileName());
+                    return true;
                 }
             }
         } catch (Exception e) {
             log.error("Failed to process HTML file: {}", path, e);
             // System continues with next file
         }
+        return false;
     }
 
     /**

--- a/src/main/java/de/maulmann/SiteBuilderPipeline.java
+++ b/src/main/java/de/maulmann/SiteBuilderPipeline.java
@@ -82,6 +82,15 @@ public class SiteBuilderPipeline {
             timeTracker.save();
             SitemapGenerator.generate(); // Sitemap & robots.txt now ready for Phase 3
 
+            // --- PHASE 1.5: Inject Firestore Ratings ---
+            System.out.println("\n[PHASE 1.5] Injecting Firestore ratings...");
+            String firebaseCreds = System.getenv("FIREBASE_SERVICE_ACCOUNT_JSON");
+            if (firebaseCreds == null || firebaseCreds.isEmpty()) {
+                System.err.println("⚠️ WARNING: FIREBASE_SERVICE_ACCOUNT_JSON is missing! Ratings will NOT be injected.");
+            } else {
+                FirestoreRatingInjector.main(new String[0]);
+            }
+
             // --- PHASE 2: Convert Images to WebP ---
             System.out.println("\n[PHASE 2] Converting images to WebP...");
             ImageConverter.main(new String[0]);


### PR DESCRIPTION
Integrated the FirestoreRatingInjector into the site build pipeline. The injector now runs right after the files are generated in plain HTML and before any compression or image conversion. Each successful rating injection is logged, and a final summary is provided. Additionally, the pipeline now checks for the presence of the FIREBASE_SERVICE_ACCOUNT_JSON environment variable and issues a warning if it's missing, fulfilling the user's request for credential verification.

---
*PR created automatically by Jules for task [16435065668645884901](https://jules.google.com/task/16435065668645884901) started by @AndreasBild*