### PR TITLE
Initialize Firebase SDK via service account file

### DIFF
--- a/src/main/java/de/maulmann/FirestoreRatingInjector.java
+++ b/src/main/java/de/maulmann/FirestoreRatingInjector.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -51,22 +52,32 @@ public class FirestoreRatingInjector {
 
     /**
      * Initializes the Firebase Admin SDK using a service account JSON string
-     * provided via environment variable for CI/CD compatibility.
+     * provided via environment variable or a local JSON file.
      */
     private static void initFirebase() throws IOException {
         String serviceAccountJson = System.getenv("FIREBASE_SERVICE_ACCOUNT_JSON");
-        if (serviceAccountJson == null || serviceAccountJson.isEmpty()) {
-            log.error("Environment variable FIREBASE_SERVICE_ACCOUNT_JSON is missing.");
-            throw new IllegalStateException("FIREBASE_SERVICE_ACCOUNT_JSON not set.");
+        String serviceAccountPath = "firebase/maulmann-3f90d-firebase-adminsdk-fbsvc-78c9f10838";
+
+        FirebaseOptions.Builder optionsBuilder = FirebaseOptions.builder();
+
+        if (serviceAccountJson != null && !serviceAccountJson.isEmpty()) {
+            log.info("Initializing Firebase using JSON from environment variable.");
+            optionsBuilder.setCredentials(GoogleCredentials.fromStream(
+                    new ByteArrayInputStream(serviceAccountJson.getBytes(StandardCharsets.UTF_8))));
+        } else {
+            File serviceAccountFile = new File(serviceAccountPath);
+            if (serviceAccountFile.exists()) {
+                log.info("Initializing Firebase using service account file: {}", serviceAccountPath);
+                optionsBuilder.setCredentials(GoogleCredentials.fromStream(
+                        new FileInputStream(serviceAccountFile)));
+            } else {
+                log.error("Firebase credentials missing. Neither FIREBASE_SERVICE_ACCOUNT_JSON env var nor file at {} exists.", serviceAccountPath);
+                throw new IllegalStateException("Firebase credentials not found.");
+            }
         }
 
-        FirebaseOptions options = FirebaseOptions.builder()
-                .setCredentials(GoogleCredentials.fromStream(
-                        new ByteArrayInputStream(serviceAccountJson.getBytes(StandardCharsets.UTF_8))))
-                .build();
-
         if (FirebaseApp.getApps().isEmpty()) {
-            FirebaseApp.initializeApp(options);
+            FirebaseApp.initializeApp(optionsBuilder.build());
             log.info("Firebase Admin SDK initialized successfully.");
         }
     }

--- a/src/main/java/de/maulmann/SiteBuilderPipeline.java
+++ b/src/main/java/de/maulmann/SiteBuilderPipeline.java
@@ -85,8 +85,10 @@ public class SiteBuilderPipeline {
             // --- PHASE 1.5: Inject Firestore Ratings ---
             System.out.println("\n[PHASE 1.5] Injecting Firestore ratings...");
             String firebaseCreds = System.getenv("FIREBASE_SERVICE_ACCOUNT_JSON");
-            if (firebaseCreds == null || firebaseCreds.isEmpty()) {
-                System.err.println("⚠️ WARNING: FIREBASE_SERVICE_ACCOUNT_JSON is missing! Ratings will NOT be injected.");
+            File firebaseFile = new File("firebase/maulmann-3f90d-firebase-adminsdk-fbsvc-78c9f10838");
+
+            if ((firebaseCreds == null || firebaseCreds.isEmpty()) && !firebaseFile.exists()) {
+                System.err.println("⚠️ WARNING: Firebase credentials (env or file) are missing! Ratings will NOT be injected.");
             } else {
                 FirestoreRatingInjector.main(new String[0]);
             }


### PR DESCRIPTION
This change allows the Firebase Admin SDK to be initialized using a local service account JSON file, as requested. It implements a fallback mechanism that first checks for the `FIREBASE_SERVICE_ACCOUNT_JSON` environment variable and then looks for the specific file at `firebase/maulmann-3f90d-firebase-adminsdk-fbsvc-78c9f10838`. The `SiteBuilderPipeline` was also updated to prevent unnecessary warning messages when the file-based initialization method is used.

---
*PR created automatically by Jules for task [5858131844761877318](https://jules.google.com/task/5858131844761877318) started by @AndreasBild*