### PR TITLE
Bold key details in card snapshot on detail pages

### DIFF
--- a/src/main/java/de/maulmann/CardPageGenerator.java
+++ b/src/main/java/de/maulmann/CardPageGenerator.java
@@ -396,7 +396,7 @@ public class CardPageGenerator {
         data.put("nextLink", next != null ? "../" + next.seasonFolder + "/" + next.filename : null);
 
         data.put("h1Title", h1Title);
-        data.put("aiSnapshotText", metaDesc);
+        data.put("aiSnapshotText", generateAiSnapshotText(c));
 
         data.put("frontImgPath", frontImgPath);
         data.put("backImgPath", backImgPath);
@@ -534,6 +534,34 @@ public class CardPageGenerator {
             else sb.append("Numbered ").append(c.get("Serial")).append("/").append(c.get("Print Run")).append(". ");
         }
         sb.append("A must-see for any ").append(c.get("Player")).append(" Super Collector. High-res scans and hobby history.");
+        return sb.toString();
+    }
+
+    private static String generateAiSnapshotText(CardData c) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("View details for the ");
+        sb.append("<strong>").append(escapeHtml(c.get("Season"))).append(" ").append(escapeHtml(c.get("Brand"))).append(" ").append(escapeHtml(c.get("Player"))).append("</strong>");
+        sb.append(" card #").append(escapeHtml(c.get("Number"))).append(" from our ").append(escapeHtml(c.get("Player"))).append(" Private Collection. ");
+
+        if (c.has("Variant")) {
+            sb.append("Rare <strong>").append(escapeHtml(c.get("Variant"))).append("</strong> variant. ");
+        }
+
+        String combinedSerial = c.get("Serial/Print Run");
+        if (isValid(combinedSerial)) {
+            if (combinedSerial.contains("1/1") || combinedSerial.equals("1")) {
+                sb.append("Includes <strong>1/1 Masterpiece</strong> details. ");
+            } else {
+                sb.append("Serial numbered <strong>").append(escapeHtml(combinedSerial)).append("</strong>. ");
+            }
+        } else if (c.has("Serial")) {
+            if (c.get("Serial").equals("1") && c.get("Print Run").equals("1")) {
+                sb.append("One-of-One (<strong>1/1</strong>) Masterpiece. ");
+            } else {
+                sb.append("Numbered <strong>").append(escapeHtml(c.get("Serial"))).append("/").append(escapeHtml(c.get("Print Run"))).append("</strong>. ");
+            }
+        }
+        sb.append("A must-see for any ").append(escapeHtml(c.get("Player"))).append(" Super Collector. High-res scans and hobby history.");
         return sb.toString();
     }
 

--- a/src/main/resources/templates/card-detail.ftlh
+++ b/src/main/resources/templates/card-detail.ftlh
@@ -36,7 +36,7 @@ ${topNavHtml?no_esc}
     </header>
 
     <div class="ai-summary">
-        <p><strong>Card Snapshot:</strong> ${aiSnapshotText}</p>
+        <p><strong>Card Snapshot:</strong> ${aiSnapshotText?no_esc}</p>
     </div>
 
     <div class="card-images-container">


### PR DESCRIPTION
This change enhances the visual presentation of individual card detail pages by bolding the most important information in the "Card Snapshot" section. Specifically, the card's name (Season, Brand, Player), its variant, and its serial number/print run details are now bolded.

To achieve this safely:
1. A new method `generateAiSnapshotText` was added to `CardPageGenerator.java`. It escapes all dynamic values before wrapping them in `<strong>` tags.
2. The `aiSnapshotText` variable in the FreeMarker data model now contains this HTML string, while `metaDesc` remains plain text for use in meta tags and JSON-LD.
3. The `card-detail.ftlh` template was updated to use `${aiSnapshotText?no_esc}` for rendering the rich text.

Visual verification was performed, confirming that the bolding appears correctly on the page while SEO metadata remains unaffected.

---
*PR created automatically by Jules for task [2369795998202175005](https://jules.google.com/task/2369795998202175005) started by @AndreasBild*